### PR TITLE
change wrong key names of the options object given in the Android example

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,8 +295,8 @@ An object with the following keys:
 
 ```js
 const options = {
-  price: '80.00',
-  currency: 'USD',
+  total_price: '80.00',
+  currency_code: 'USD',
   line_items: [{
     currency_code: 'USD',
     description: 'Whisky',


### PR DESCRIPTION
### Improve Readme Example code snippet

In the given Android example in Readme (https://github.com/tipsi/tipsi-stripe#example-2) there are two wrong key names of the options object (`price` & `currency`), that is causing a problem with the native code here https://github.com/tipsi/tipsi-stripe/blob/master/android/src/main/java/com/gettipsi/stripe/StripeModule.java#L55

It would be great if you can merge the changes to prevent further misleading.

Thanks!
