### PR TITLE
Add notes in README.md to describe enabling Apple Pay in a real device (Fix #77)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ Run `react-native link tipsi-stripe` so your project is linked against your Xcod
 5. Whenever you want to use it within React code now you can:
   * `import stripe from 'tipsi-stripe'`
 
+#### Running Apple Pay in a Real Device
+
+In order to run Apple Pay on an Apple device (as opposed to a simulator), there's an extra step you need to complete in XCode.
+
+Navigate to the Capabilities tab in your XCode project and turn Apple Pay on. Then, add your Apple Pay Merchant ID
+to the 'Merchant IDs' section by clicking the '+' icon. Finally, make sure that the checkbox next to your merchant ID is blue and checked off.
+
+![tipsiapplepay](https://user-images.githubusercontent.com/24738825/28348524-4bbd78e6-6bf2-11e7-97ed-b6e4b4ee0f0e.png)
 ### Android
 
 #### react-native cli

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Run `react-native link tipsi-stripe` so your project is linked against your Xcod
 
 #### Running Apple Pay in a Real Device
 
-In order to run Apple Pay on an Apple device (as opposed to a simulator), there's an extra step you need to complete in XCode.
+In order to run Apple Pay on an Apple device (as opposed to a simulator), there's an extra step you need to complete in XCode. Without completing this step, Apple Pay will say that it is not supported - even if Apple Pay is set up correctly on the device.
 
 Navigate to the Capabilities tab in your XCode project and turn Apple Pay on. Then, add your Apple Pay Merchant ID
 to the 'Merchant IDs' section by clicking the '+' icon. Finally, make sure that the checkbox next to your merchant ID is blue and checked off.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Navigate to the Capabilities tab in your XCode project and turn Apple Pay on. Th
 to the 'Merchant IDs' section by clicking the '+' icon. Finally, make sure that the checkbox next to your merchant ID is blue and checked off.
 
 ![tipsiapplepay](https://user-images.githubusercontent.com/24738825/28348524-4bbd78e6-6bf2-11e7-97ed-b6e4b4ee0f0e.png)
+
 ### Android
 
 #### react-native cli


### PR DESCRIPTION
README.md currently does not describe an issue with using Apple Pay in a real device (as opposed to a simulator), which left me and a couple confused when deviceDoesSupportApplePay() returned false even though Apple Pay was set up correctly on the device. This PR fixes that by adding the notes to README.md.

I tried to match the formatting of the readme, but let me know if theres an issue or feel free to change it to whatever format needed.

Fix for #77