### PR TITLE
Fix for 0.47 Breaking Change with createJSModules Override

### DIFF
--- a/android/src/main/java/com/gettipsi/stripe/StripeReactPackage.java
+++ b/android/src/main/java/com/gettipsi/stripe/StripeReactPackage.java
@@ -20,7 +20,8 @@ public class StripeReactPackage implements ReactPackage {
     return modules;
   }
 
-  @Override
+  // Deprecated RN 0.47
+  //@Override
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }

--- a/android/src/main/java/com/gettipsi/stripe/StripeReactPackage.java
+++ b/android/src/main/java/com/gettipsi/stripe/StripeReactPackage.java
@@ -20,8 +20,6 @@ public class StripeReactPackage implements ReactPackage {
     return modules;
   }
 
-  // Deprecated RN 0.47
-  //@Override
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }


### PR DESCRIPTION
Fix for a breaking change made in react native 0.47 "Remove unused createJSModules calls"