### PR TITLE
Added createSourceWithParams method for iOS (#112)

### DIFF
--- a/.travis/before-install.sh
+++ b/.travis/before-install.sh
@@ -11,6 +11,7 @@ init_new_example_project() {
     package.json
     index.{ios,android}.js
     android/app/build.gradle
+    ios/example/AppDelegate.m
     src
     scripts
     __tests__
@@ -45,15 +46,10 @@ esac
 
 npm install -g react-native-cli
 
-library_name=$(node -p "require('./package.json').name")
-library_version=$(node -p "require('./package.json').version")
-
 # Remove existing tarball
 rm -rf *.tgz
 
 # Create new tarball
 npm pack
-
-tarball_name="$library_name-$library_version.tgz" ./scripts/replaceToTarball.js
 
 init_new_example_project

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 
 library_name=$(node -p "require('./package.json').name")
+library_version=$(node -p "require('./package.json').version")
 
 cd example_tmp
+
+tarball_name="$library_name-$library_version.tgz" npm run replace-tarball
+
+case "${TRAVIS_OS_NAME}" in
+  osx)
+    npm run set-stripe-url-type
+  ;;
+esac
+
 rm -rf node_modules && npm install
 
 react-native unlink $library_name

--- a/.travis/podspec/ci.sh
+++ b/.travis/podspec/ci.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 
 library_name=$(node -p "require('./package.json').name")
+library_version=$(node -p "require('./package.json').version")
 
 cd example_tmp
+
+tarball_name="$library_name-$library_version.tgz" npm run replace-tarball
+
+npm run set-stripe-url-type
+
 rm -rf node_modules && npm install
 
 npm run add-podfile

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ stripe.init({
 ```
 
 `androidPayMode` _String_ (Android only) - Corresponds to [WALLET_ENVIRONMENT](https://developers.google.com/android-pay/tutorial#about_constants
-). Can be one of: test|production. 
+). Can be one of: test|production.
 
 ### Token
 
@@ -240,6 +240,119 @@ An object with the following keys:
 }
 ```
 
+### Source
+
+A source object returned from creating a source (via `createSourceWithParams`) with the Stripe API.
+
+##### `source`
+
+An object with the following keys:
+
+* `amount` _Number_ - The amount associated with the source.
+* `clientSecret` _String_ - The client secret of the source. Used for client-side polling using a publishable key.
+* `created` _Number_ - When the source was created.
+* `currency` _String_ - The currency associated with the source.
+* `flow` _String_ - The authentication flow of the source. Can be one of: `none`|`redirect`|`verification`|`receiver`|`unknown`.
+* `livemode` _Bool_ - Whether or not this source was created in livemode. Will be `true` if you used your `Live Publishable Key`, and `false` if you used your `Test Publishable Key`.
+* `metadata` _Object_ - A set of key/value pairs associated with the source object.
+* `owner` _Object_ - Information about the owner of the payment instrument.
+* `receiver` _Object_ (Optional) - Information related to the receiver flow. Present if the source is a receiver.
+* `redirect` _Object_ (Optional) - Information related to the redirect flow. Present if the source is authenticated by a redirect.
+* `status` _String_ - The status of the source. Can be one of: `pending`|`chargable`|`consumed`|`cancelled`|`failed`.
+* `type` _String_ - The type of the source. Can be one of: `bancontact`|`bitcoin`|`card`|`griopay`|`ideal`|`sepaDebit`|`sofort`|`threeDSecure`|`alipay`|`unknown`.
+* `usage` _String_ - Whether this source should be reusable or not. Can be one of: `reusable`|`single`|`unknown`.
+* `verification` _Object_ (Optional) - Information related to the verification flow. Present if the source is authenticated by a verification.
+* `details` _Object_ - Information about the source specific to its type.
+* `cardDetails` _Object_ (Optional) - If this is a card source, this property contains information about the card.
+* `sepaDebitDetails` _Object_ (Optional) - If this is a SEPA Debit source, this property contains information about the sepaDebit.
+
+##### `owner`
+
+An object with the following keys:
+
+* `address` _Object_ (Optional) - Owner’s address.
+* `email` _String_ (Optional) - Owner’s email address.
+* `name` _String_ (Optional) - Owner’s full name.
+* `phone` _String_ (Optional) - Owner’s phone number.
+* `verifiedAddress` _Object_ (Optional) - Verified owner’s address.
+* `verifiedEmail` _String_ (Optional) - Verified owner’s email address.
+* `verifiedName` _String_ (Optional) - Verified owner’s full name.
+* `verifiedPhone` _String_ (Optional) - Verified owner’s phone number.
+
+##### `receiver`
+
+An object with the following keys:
+
+* `address` _Object_ - The address of the receiver source. This is the value that should be communicated to the customer to send their funds to.
+* `amountCharged` _Number_ - The total amount charged by you.
+* `amountReceived` _Number_ - The total amount received by the receiver source.
+* `amountReturned` _Number_ - The total amount that was returned to the customer.
+
+##### `redirect`
+
+An object with the following keys:
+
+* `returnURL` _String_ - The URL you provide to redirect the customer to after they authenticated their payment.
+* `status` _String_ - The status of the redirect. Can be one of: `pending`|`succeeded`|`failed`|`unknown`.
+* `url` _String_ - The URL provided to you to redirect a customer to as part of a redirect authentication flow.
+
+##### `verification`
+
+An object with the following keys:
+
+* `attemptsRemaining` _Number_ - The number of attempts remaining to authenticate the source object with a verification code.
+* `status` _String_ - The status of the verification. Can be one of: `pending`|`succeeded`|`failed`|`unknown`.
+
+##### `cardDetails`
+
+An object with the following keys:
+
+* `last4` _String_ - The last 4 digits of the card.
+* `expMonth` _Number_ - The card’s expiration month. 1-indexed (i.e. 1 == January)
+* `expYear` _Number_ - The card’s expiration year.
+* `brand` _String_ - The issuer of the card. Can be one of: `JCB`|`American Express`|`Visa`|`Discover`|`Diners Club`|`MasterCard`|`Unknown`.
+* `funding` _String_ (iOS only) - The funding source for the card. Can be one of: `debit`|`credit`|`prepaid`|`unknown`.
+* `country` _String_ - Two-letter ISO code representing the issuing country of the card.
+* `threeDSecure` _String_ Whether 3D Secure is supported or required by the card. Can be one of: `required`|`optional`|`notSupported`|`unknown`.
+
+##### `sepaDebitDetails`
+
+An object with the following keys:
+
+* `last4` _String_ - The last 4 digits of the account number.
+* `bankCode` _String_ - The account’s bank code.
+* `country` _String_ - Two-letter ISO code representing the country of the bank account.
+* `fingerprint` _String_ - The account’s fingerprint.
+* `mandateReference` _String_ The reference of the mandate accepted by your customer.
+* `mandateURL` _String_ - The details of the mandate accepted by your customer.
+
+#### Example
+
+```js
+{
+  livemode: false,
+  amount: 50,
+  owner: {},
+  metadata: {},
+  clientSecret: 'src_client_secret_BLnXIZxZprDmdhw3zv12123L',
+  details: {
+    native_url: null,
+    statement_descriptor: null
+  },
+  type: 'alipay',
+  redirect: {
+    url: 'https://hooks.stripe.com/redirect/authenticate/src_1Az5vzE5aJKqY779Kes5s61m?client_secret=src_client_secret_BLnXIZxZprDmdhw3zv12123L',
+    returnURL: 'example://stripe-redirect?redirect_merchant_name=example',
+    status: 'succeeded'
+  },
+  usage: 'single',
+  created: 1504713563,
+  flow: 'redirect',
+  currency: 'eur',
+  status: 'chargable',
+}
+```
+
 ### Apple Pay (iOS only)
 
 #### `openApplePaySetup()`
@@ -288,7 +401,8 @@ An object with the following keys:
 * `requiredBillingAddressFields` _Array\<String\>_ - A bit field of billing address fields that you need in order to process the transaction. Can be one of: `all`|`name`|`email`|`phone`|`postal_address` or not specify to disable.
 * `requiredShippingAddressFields` _Array\<String\>_ - A bit field of shipping address fields that you need in order to process the transaction. Can be one of: `all`|`name`|`email`|`phone`|`postal_address` or not specify to disable.
 * `shippingMethods` _Array_ - An array of `shippingMethod` objects that describe the supported shipping methods.
-* `currencyCode` _String_ - The three-letter ISO 4217 currency code.
+* `currencyCode` _String_ - The three-letter ISO 4217 currency code. Default `USD`.
+* `countryCode` _String_ - The two-letter code for the country where the payment will be processed. Default `US`.
 
 ##### `shippingMethod`
 
@@ -434,7 +548,6 @@ An object with the following keys:
 * `requiredBillingAddressFields` _String_ - The billing address fields the user must fill out when prompted for their payment details. Can be one of: `full`|`zip` or not specify to disable.
 * `prefilledInformation` _Object_ - You can set this property to pre-fill any information you’ve already collected from your user.
 * `managedAccountCurrency` _String_ - Required to be able to add the card to an account (in all other cases, this parameter is not used). [More info](https://stripe.com/docs/api#create_card_token-card-currency).
-* `smsAutofillDisabled` _Bool_ - When entering their payment information, users who have a saved card with Stripe will be prompted to autofill it by entering an SMS code. Set this property to `true` to disable this feature.
 * `theme` _Object_ - Can be used to visually style Stripe-provided UI.
 
 ##### `prefilledInformation`
@@ -477,7 +590,6 @@ An object with the following keys:
 
 ```js
 const options = {
-  smsAutofillDisabled: true,
   requiredBillingAddressFields: 'full',
   prefilledInformation: {
     billingAddress: {
@@ -666,6 +778,57 @@ class FieldExample extends Component {
     )
   }
 }
+```
+
+### Create source object with params (iOS only at the moment)
+
+#### `createSourceWithParams(params) -> Promise`
+
+Creates source object based on params. Sources are used to create payments for a variety of [payment methods](https://stripe.com/docs/sources)
+
+_NOTE_: For sources that require redirecting your customer to authorize the payment, you need to specify a return URL when you create the source. This allows your customer to be redirected back to your app after they authorize the payment. For this return URL, you can either use a custom URL scheme or a universal link supported by your app. For more information on registering and handling URLs in your app, refer to the Apple documentation:
+
+* [Implementing Custom URL Schemes](https://developer.apple.com/library/content/documentation/iPhone/Conceptual/iPhoneOSProgrammingGuide/Inter-AppCommunication/Inter-AppCommunication.html#//apple_ref/doc/uid/TP40007072-CH6-SW10)
+* [Supporting Universal Links](https://developer.apple.com/library/content/documentation/General/Conceptual/AppSearch/UniversalLinks.html)
+
+You also need to setup your `AppDelegate.m` app delegate to forward URLs to the Stripe SDK according to the [official iOS implementation](https://stripe.com/docs/mobile/ios/sources#redirecting-your-customer)
+
+##### `params`
+
+An object with the following keys:
+(Depending on the type you need to provide different params. Check the [STPSourceParams docs](https://stripe.github.io/stripe-ios/docs/Classes/STPSourceParams.html) for reference)
+
+* `type` _String_ (Required) - The type of the source to create. Can be one of: `bancontact`|`bitcoin`|`card`|`griopay`|`ideal`|`sepaDebit`|`sofort`|`threeDSecure`|`alipay`.
+* `amount` _Number_ - A positive number in the smallest currency unit representing the amount to charge the customer (e.g., 1099 for a €10.99 payment).
+* `name` _String_ - The full name of the account holder.
+* `returnURL` _String_ The URL the customer should be redirected to after they have successfully verified the payment.
+* `statementDescriptor` _String_ A custom statement descriptor for the payment.
+* `currency` _String_ - The currency associated with the source. This is the currency for which the source will be chargeable once ready.
+* `email` _String_ - The customer’s email address.
+* `bank` _String_ - The customer’s bank.
+* `iban` _String_ - The IBAN number for the bank account you wish to debit.
+* `addressLine1` _String_ - The bank account holder’s first address line (optional).
+* `city` _String_ - The bank account holder’s city.
+* `postalCode` _String_ - The bank account holder’s postal code.
+* `country` _String_ - The bank account holder’s two-letter country code (`sepaDebit`) or the country code of the customer’s bank (`sofort`).
+* `card` _String_ - The ID of the card source.
+
+##### Example
+
+![Source Params iOS](https://user-images.githubusercontent.com/5305150/30137085-019fa90e-9362-11e7-9e6b-b934d6e68b60.gif)
+
+```js
+const params = {
+  type: 'alipay',
+  amount: 5,
+  currency: 'EUR',
+  returnURL: 'example://stripe-redirect',
+}
+
+const source = await stripe.createSourceWithParams(params)
+
+// Client specific code
+// api.sendSourceToBackend(source)
 ```
 
 ## Tests

--- a/example/__tests__/06_test_sources.ios.js
+++ b/example/__tests__/06_test_sources.ios.js
@@ -1,0 +1,49 @@
+import helper from 'tipsi-appium-helper'
+import test from './utils/tape'
+import openTestSuite from './common/openTestSuite'
+import swipeUp from './common/swipeUp'
+import idFromLabel from './common/idFromLabel'
+
+const { driver, idFromAccessId } = helper
+
+test('Test if user can create a source object for Alipay', async (t) => {
+  const expectedSourcesResults = [false, true]
+
+  await openTestSuite('Sources')
+
+  for (const sourcesVisibility of expectedSourcesResults) {
+    const sourceButtonId = idFromAccessId('sourceButton')
+    const sourceObject = idFromAccessId('sourceObject')
+
+    await driver.waitForVisible(sourceButtonId, 60000)
+    t.pass('User should see `Create a source with params` button')
+
+    await driver.click(sourceButtonId)
+    t.pass('User should be able to tap on `Create source for Alipay payment` button')
+
+    const paymentParametersHeaderId = idFromLabel('Payment parameters')
+    await driver.waitForVisible(paymentParametersHeaderId, 60000)
+    await swipeUp(paymentParametersHeaderId, 300)
+    t.pass('User should swipe to button')
+
+    const testPaymentButtonId = sourcesVisibility
+      ? idFromLabel('Authorize Test Payment')
+      : idFromLabel('Fail Test Payment')
+    await driver.waitForVisible(testPaymentButtonId, 60000)
+    await driver.click(testPaymentButtonId)
+    t.pass('User should click on "Authorize Test Payment" button')
+
+    const returnToTheAppButtonId = idFromLabel('Return to example')
+    await driver.waitForVisible(returnToTheAppButtonId, 60000)
+    await driver.click(returnToTheAppButtonId)
+    t.pass('User should click on "Return to example" button')
+
+    const openButtonId = idFromLabel('Open')
+    await driver.waitForVisible(openButtonId, 60000)
+    await driver.click(openButtonId)
+    t.pass('User should click on "Open" button')
+
+    await driver.waitForVisible(sourceObject, 60000, !sourcesVisibility)
+    t.pass('User should see source object')
+  }
+})

--- a/example/__tests__/common/idFromLabel.js
+++ b/example/__tests__/common/idFromLabel.js
@@ -1,0 +1,1 @@
+export default label => `//*[@label="${label}"]`

--- a/example/__tests__/common/swipeUp.js
+++ b/example/__tests__/common/swipeUp.js
@@ -1,0 +1,16 @@
+import helper from 'tipsi-appium-helper'
+
+const { driver } = helper
+
+export default async function swipeUp(selector, yoffset = 0) {
+  const element = await driver.element(selector)
+  await driver.touchPerform([{
+    action: 'press',
+    options: { element: element.value.ELEMENT },
+  }, {
+    action: 'moveTo',
+    options: { x: 0, y: yoffset * -1 },
+  }, {
+    action: 'release',
+  }])
+}

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -6,7 +6,7 @@ workspace 'example'
 
 target 'example' do
   # Stripe
-  pod 'Stripe', '~> 10.1.0'
+  pod 'Stripe', '~> 11.2.0'
 
   # Install additional dependencies
   pod 'Firebase/Core'

--- a/example/ios/example.xcodeproj/project.pbxproj
+++ b/example/ios/example.xcodeproj/project.pbxproj
@@ -7,36 +7,36 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		00C302E51ABCBA2D00DB3ED1 /* ReferenceProxy in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
-		00C302E71ABCBA2D00DB3ED1 /* ReferenceProxy in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
-		00C302E81ABCBA2D00DB3ED1 /* ReferenceProxy in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302C01ABCB91800DB3ED1 /* libRCTImage.a */; };
-		00C302E91ABCBA2D00DB3ED1 /* ReferenceProxy in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302DC1ABCB9D200DB3ED1 /* libRCTNetwork.a */; };
-		00C302EA1ABCBA2D00DB3ED1 /* ReferenceProxy in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302E41ABCB9EE00DB3ED1 /* libRCTVibration.a */; };
+		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
+		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
+		00C302E81ABCBA2D00DB3ED1 /* libRCTImage.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302C01ABCB91800DB3ED1 /* libRCTImage.a */; };
+		00C302E91ABCBA2D00DB3ED1 /* libRCTNetwork.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302DC1ABCB9D200DB3ED1 /* libRCTNetwork.a */; };
+		00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302E41ABCB9EE00DB3ED1 /* libRCTVibration.a */; };
 		00E356F31AD99517003FC87E /* exampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* exampleTests.m */; };
-		133E29F31AD74F7200F7D852 /* ReferenceProxy in Frameworks */ = {isa = PBXBuildFile; fileRef = 78C398B91ACF4ADC00677621 /* libRCTLinking.a */; };
-		139105C61AF99C1200B5F7CC /* ReferenceProxy in Frameworks */ = {isa = PBXBuildFile; fileRef = 139105C11AF99BAD00B5F7CC /* libRCTSettings.a */; };
-		139FDEF61B0652A700C62182 /* ReferenceProxy in Frameworks */ = {isa = PBXBuildFile; fileRef = 139FDEF41B06529B00C62182 /* libRCTWebSocket.a */; };
+		133E29F31AD74F7200F7D852 /* libRCTLinking.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 78C398B91ACF4ADC00677621 /* libRCTLinking.a */; };
+		139105C61AF99C1200B5F7CC /* libRCTSettings.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 139105C11AF99BAD00B5F7CC /* libRCTSettings.a */; };
+		139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 139FDEF41B06529B00C62182 /* libRCTWebSocket.a */; };
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB11A68108700A75B9A /* LaunchScreen.xib */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		140ED2AC1D01E1AD002B40FF /* ReferenceProxy in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
-		146834051AC3E58100842450 /* ReferenceProxy in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
+		140ED2AC1D01E1AD002B40FF /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
+		146834051AC3E58100842450 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
 		2D02E4BC1E0B4A80006451C7 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		2D02E4BD1E0B4A84006451C7 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		2D02E4BF1E0B4AB3006451C7 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		2D02E4C21E0B4AEC006451C7 /* ReferenceProxy in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157351DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
-		2D02E4C31E0B4AEC006451C7 /* ReferenceProxy in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DAD3E841DF850E9000B6D8A /* libRCTImage-tvOS.a */; };
-		2D02E4C41E0B4AEC006451C7 /* ReferenceProxy in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DAD3E881DF850E9000B6D8A /* libRCTLinking-tvOS.a */; };
-		2D02E4C51E0B4AEC006451C7 /* ReferenceProxy in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DAD3E8C1DF850E9000B6D8A /* libRCTNetwork-tvOS.a */; };
-		2D02E4C61E0B4AEC006451C7 /* ReferenceProxy in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DAD3E901DF850E9000B6D8A /* libRCTSettings-tvOS.a */; };
-		2D02E4C71E0B4AEC006451C7 /* ReferenceProxy in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DAD3E941DF850E9000B6D8A /* libRCTText-tvOS.a */; };
-		2D02E4C81E0B4AEC006451C7 /* ReferenceProxy in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DAD3E991DF850E9000B6D8A /* libRCTWebSocket-tvOS.a */; };
-		2D02E4C91E0B4AEC006451C7 /* ReferenceProxy in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DAD3EA31DF850E9000B6D8A /* libReact.a */; };
+		2D02E4C21E0B4AEC006451C7 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157351DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
+		2D02E4C31E0B4AEC006451C7 /* libRCTImage-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DAD3E841DF850E9000B6D8A /* libRCTImage-tvOS.a */; };
+		2D02E4C41E0B4AEC006451C7 /* libRCTLinking-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DAD3E881DF850E9000B6D8A /* libRCTLinking-tvOS.a */; };
+		2D02E4C51E0B4AEC006451C7 /* libRCTNetwork-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DAD3E8C1DF850E9000B6D8A /* libRCTNetwork-tvOS.a */; };
+		2D02E4C61E0B4AEC006451C7 /* libRCTSettings-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DAD3E901DF850E9000B6D8A /* libRCTSettings-tvOS.a */; };
+		2D02E4C71E0B4AEC006451C7 /* libRCTText-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DAD3E941DF850E9000B6D8A /* libRCTText-tvOS.a */; };
+		2D02E4C81E0B4AEC006451C7 /* libRCTWebSocket-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DAD3E991DF850E9000B6D8A /* libRCTWebSocket-tvOS.a */; };
+		2D02E4C91E0B4AEC006451C7 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DAD3EA31DF850E9000B6D8A /* libReact.a */; };
 		2DCD954D1E0B4F2C00145EB5 /* exampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* exampleTests.m */; };
 		3622726D30774B42B11BA7DB /* libTPSStripe.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EF1D05F943949BC98E5AE3E /* libTPSStripe.a */; };
-		5E9157361DD0AC6A00FF2AA8 /* ReferenceProxy in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
-		832341BD1AAA6AB300B99B32 /* ReferenceProxy in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
+		5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
+		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 		9CCBE88CAEDFC3D51AA8DFED /* libPods-example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 84EE98FDC5E37E45473F9930 /* libPods-example.a */; };
 /* End PBXBuildFile section */
 
@@ -276,7 +276,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				140ED2AC1D01E1AD002B40FF /* ReferenceProxy in Frameworks */,
+				140ED2AC1D01E1AD002B40FF /* libReact.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -284,17 +284,17 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				146834051AC3E58100842450 /* ReferenceProxy in Frameworks */,
-				5E9157361DD0AC6A00FF2AA8 /* ReferenceProxy in Frameworks */,
-				00C302E51ABCBA2D00DB3ED1 /* ReferenceProxy in Frameworks */,
-				00C302E71ABCBA2D00DB3ED1 /* ReferenceProxy in Frameworks */,
-				00C302E81ABCBA2D00DB3ED1 /* ReferenceProxy in Frameworks */,
-				133E29F31AD74F7200F7D852 /* ReferenceProxy in Frameworks */,
-				00C302E91ABCBA2D00DB3ED1 /* ReferenceProxy in Frameworks */,
-				139105C61AF99C1200B5F7CC /* ReferenceProxy in Frameworks */,
-				832341BD1AAA6AB300B99B32 /* ReferenceProxy in Frameworks */,
-				00C302EA1ABCBA2D00DB3ED1 /* ReferenceProxy in Frameworks */,
-				139FDEF61B0652A700C62182 /* ReferenceProxy in Frameworks */,
+				146834051AC3E58100842450 /* libReact.a in Frameworks */,
+				5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */,
+				00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */,
+				00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */,
+				00C302E81ABCBA2D00DB3ED1 /* libRCTImage.a in Frameworks */,
+				133E29F31AD74F7200F7D852 /* libRCTLinking.a in Frameworks */,
+				00C302E91ABCBA2D00DB3ED1 /* libRCTNetwork.a in Frameworks */,
+				139105C61AF99C1200B5F7CC /* libRCTSettings.a in Frameworks */,
+				832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */,
+				00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */,
+				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
 				3622726D30774B42B11BA7DB /* libTPSStripe.a in Frameworks */,
 				9CCBE88CAEDFC3D51AA8DFED /* libPods-example.a in Frameworks */,
 			);
@@ -304,14 +304,14 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2D02E4C91E0B4AEC006451C7 /* ReferenceProxy in Frameworks */,
-				2D02E4C21E0B4AEC006451C7 /* ReferenceProxy in Frameworks */,
-				2D02E4C31E0B4AEC006451C7 /* ReferenceProxy in Frameworks */,
-				2D02E4C41E0B4AEC006451C7 /* ReferenceProxy in Frameworks */,
-				2D02E4C51E0B4AEC006451C7 /* ReferenceProxy in Frameworks */,
-				2D02E4C61E0B4AEC006451C7 /* ReferenceProxy in Frameworks */,
-				2D02E4C71E0B4AEC006451C7 /* ReferenceProxy in Frameworks */,
-				2D02E4C81E0B4AEC006451C7 /* ReferenceProxy in Frameworks */,
+				2D02E4C91E0B4AEC006451C7 /* libReact.a in Frameworks */,
+				2D02E4C21E0B4AEC006451C7 /* libRCTAnimation.a in Frameworks */,
+				2D02E4C31E0B4AEC006451C7 /* libRCTImage-tvOS.a in Frameworks */,
+				2D02E4C41E0B4AEC006451C7 /* libRCTLinking-tvOS.a in Frameworks */,
+				2D02E4C51E0B4AEC006451C7 /* libRCTNetwork-tvOS.a in Frameworks */,
+				2D02E4C61E0B4AEC006451C7 /* libRCTSettings-tvOS.a in Frameworks */,
+				2D02E4C71E0B4AEC006451C7 /* libRCTText-tvOS.a in Frameworks */,
+				2D02E4C81E0B4AEC006451C7 /* libRCTWebSocket-tvOS.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/example/ios/example/AppDelegate.m
+++ b/example/ios/example/AppDelegate.m
@@ -11,6 +11,7 @@
 
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
+#import <Stripe/Stripe.h>
 
 @implementation AppDelegate
 
@@ -32,6 +33,18 @@
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
   return YES;
+}
+
+// This method handles opening native URLs (e.g., "yourexampleapp://")
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+  BOOL stripeHandled = [Stripe handleStripeURLCallbackWithURL:url];
+  if (stripeHandled) {
+    return YES;
+  } else {
+    // This was not a stripe url – do whatever url handling your app
+    // normally does, if any.
+  }
+  return NO;
 }
 
 @end

--- a/example/ios/example/Info.plist
+++ b/example/ios/example/Info.plist
@@ -20,6 +20,19 @@
 	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>example</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>example</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,9 @@
     "test:android": "appium-helper --platform android",
     "test:ios": "appium-helper --platform ios",
     "test": "npm-run-all test:*",
-    "add-podfile": "scripts/add-podfile.sh"
+    "add-podfile": "scripts/add-podfile.sh",
+    "replace-tarball": "scripts/replaceToTarball.js",
+    "set-stripe-url-type": "scripts/setUrlTypeForStripe.js"
   },
   "dependencies": {
     "prop-types": "^15.5.10",

--- a/example/scripts/replaceToTarball.js
+++ b/example/scripts/replaceToTarball.js
@@ -1,21 +1,22 @@
 #!/usr/bin/env node
 const fs = require('fs')
+const path = require('path')
 
-const root = process.cwd()
+const exampleRoot = process.cwd()
 const string = '"tipsi-stripe": "file:../'
 
-function replaceConstant(path) {
-  fs.readFile(path, 'utf8', (err, data) => {
+function replaceConstant(filePath) {
+  fs.readFile(filePath, 'utf8', (err, data) => {
     if (err) {
       return err
     }
 
     const result = data.replace(string, `${string}${process.env.tarball_name}`)
-    return fs.writeFile(path, result, 'utf8', error => (
+    return fs.writeFile(filePath, result, 'utf8', error => (
       error && console.error(error) // eslint-disable-line
     ))
   })
 }
 
 
-replaceConstant(`${root}/example/package.json`)
+replaceConstant(path.join(exampleRoot, 'package.json'))

--- a/example/scripts/setUrlTypeForStripe.js
+++ b/example/scripts/setUrlTypeForStripe.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+const fs = require('fs')
+const path = require('path')
+const { execSync } = require('child_process')
+
+const exampleRoot = process.cwd()
+const infoPlistPath = path.join(exampleRoot, 'ios', 'example', 'Info.plist')
+
+const commands = [
+  'Add :CFBundleURLTypes array',
+  'Add :CFBundleURLTypes:0 dict',
+  'Add :CFBundleURLTypes:0:CFBundleTypeRole string Editor',
+  'Add :CFBundleURLTypes:0:CFBundleURLName string example',
+  'Add :CFBundleURLTypes:0:CFBundleURLSchemes array',
+  'Add :CFBundleURLTypes:0:CFBundleURLSchemes:0 string example',
+]
+
+commands.forEach(command => (
+  execSync(`/usr/libexec/PlistBuddy -x -c "${command}" "${infoPlistPath}"`)
+))

--- a/example/src/Root.js
+++ b/example/src/Root.js
@@ -10,6 +10,7 @@ import CardFormScreen from './scenes/CardFormScreen'
 import CustomCardScreen from './scenes/CustomCardScreen'
 import CustomBankScreen from './scenes/CustomBankScreen'
 import CardTextFieldScreen from './scenes/CardTextFieldScreen'
+import SourceScreen from './scenes/SourceScreen'
 import testID from './utils/testID'
 
 stripe.init({
@@ -31,6 +32,7 @@ export default class Root extends PureComponent {
       CustomCardScreen,
       CustomBankScreen,
       CardTextFieldScreen,
+      SourceScreen,
     ].filter(item => item),
   }
 

--- a/example/src/scenes/SourceScreen.js
+++ b/example/src/scenes/SourceScreen.js
@@ -1,0 +1,80 @@
+import React, { PureComponent } from 'react'
+import { View, Text, Switch, StyleSheet } from 'react-native'
+import stripe from 'tipsi-stripe'
+import Button from '../components/Button'
+import testID from '../utils/testID'
+
+/* eslint-disable no-console */
+export default class SourceScreen extends PureComponent {
+  static title = 'Sources'
+
+  state = {
+    loading: false,
+    source: null,
+  }
+
+  handleCreacteSourcePress = async () => {
+    try {
+      this.setState({ loading: true, source: null })
+      const source = await stripe.createSourceWithParams({
+        type: 'alipay',
+        amount: 50,
+        currency: 'EUR',
+        returnURL: 'example://stripe-redirect',
+      })
+
+      this.setState({ loading: false, source })
+    } catch (error) {
+      this.setState({ loading: false })
+    }
+  }
+
+  render() {
+    const { loading, source } = this.state
+
+    return (
+      <View style={styles.container}>
+        <Text style={styles.header}>
+          Source Example
+        </Text>
+        <Text style={styles.instruction}>
+          Click button to create a source.
+        </Text>
+        <Button
+          text="Create source for Alipay payment"
+          loading={loading}
+          onPress={this.handleCreacteSourcePress}
+          {...testID('sourceButton')}
+        />
+        <View style={styles.source} {...testID('sourceObject')}>
+          {source &&
+            <Text style={styles.instruction}>
+              Source: {JSON.stringify(source)}
+            </Text>
+          }
+        </View>
+      </View>
+    )
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  header: {
+    fontSize: 20,
+    textAlign: 'center',
+    margin: 10,
+  },
+  instruction: {
+    textAlign: 'center',
+    color: '#333333',
+    marginBottom: 5,
+  },
+  source: {
+    height: 20,
+  },
+})

--- a/ios/TPSStripe/TPSStripeManager.m
+++ b/ios/TPSStripe/TPSStripeManager.m
@@ -229,6 +229,96 @@ RCT_EXPORT_METHOD(createTokenWithBankAccount:(NSDictionary *)params
     }];
 }
 
+RCT_EXPORT_METHOD(createSourceWithParams:(NSDictionary *)params
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    if(!requestIsCompleted) {
+        reject(
+               [NSString stringWithFormat:@"%ld", (long)3],
+               @"Previous request is not completed",
+               [[NSError alloc] initWithDomain:@"StripeNative" code:3 userInfo:@{NSLocalizedDescriptionKey:@"Previous request is not completed"}]
+               );
+        return;
+    }
+
+    requestIsCompleted = NO;
+
+    NSString *sourceType = params[@"type"];
+    STPSourceParams *sourceParams;
+    if ([sourceType isEqualToString:@"bancontact"]) {
+         sourceParams = [STPSourceParams bancontactParamsWithAmount:[[params objectForKey:@"amount"] unsignedIntegerValue] name:params[@"name"] returnURL:params[@"returnURL"] statementDescriptor:params[@"statementDescriptor"]];
+    }
+    if ([sourceType isEqualToString:@"bitcoin"]) {
+         sourceParams = [STPSourceParams bitcoinParamsWithAmount:[[params objectForKey:@"amount"] unsignedIntegerValue] currency:params[@"currency"] email:params[@"email"]];
+    }
+    if ([sourceType isEqualToString:@"griopay"]) {
+         sourceParams = [STPSourceParams giropayParamsWithAmount:[[params objectForKey:@"amount"] unsignedIntegerValue] name:params[@"name"] returnURL:params[@"returnURL"] statementDescriptor:params[@"statementDescriptor"]];
+    }
+    if ([sourceType isEqualToString:@"ideal"]) {
+         sourceParams = [STPSourceParams idealParamsWithAmount:[[params objectForKey:@"amount"] unsignedIntegerValue] name:params[@"name"] returnURL:params[@"returnURL"] statementDescriptor:params[@"statementDescriptor"] bank:params[@"bank"]];
+    }
+    if ([sourceType isEqualToString:@"sepaDebit"]) {
+         sourceParams = [STPSourceParams sepaDebitParamsWithName:params[@"name"] iban:params[@"iban"] addressLine1:params[@"addressLine1"] city:params[@"city"] postalCode:params[@"postalCode"] country:params[@"country"]];
+    }
+    if ([sourceType isEqualToString:@"sofort"]) {
+         sourceParams = [STPSourceParams sofortParamsWithAmount:[[params objectForKey:@"amount"] unsignedIntegerValue] returnURL:params[@"returnURL"] country:params[@"country"] statementDescriptor:params[@"statementDescriptor"]];
+    }
+    if ([sourceType isEqualToString:@"threeDSecure"]) {
+         sourceParams = [STPSourceParams threeDSecureParamsWithAmount:[[params objectForKey:@"amount"] unsignedIntegerValue] currency:params[@"currency"] returnURL:params[@"returnURL"] card:params[@"card"]];
+    }
+    if ([sourceType isEqualToString:@"alipay"]) {
+         sourceParams = [STPSourceParams alipayParamsWithAmount:[[params objectForKey:@"amount"] unsignedIntegerValue] currency:params[@"currency"] returnURL:params[@"returnURL"]];
+    }
+
+    [[STPAPIClient sharedClient] createSourceWithParams:sourceParams completion:^(STPSource *source, NSError *error) {
+        requestIsCompleted = YES;
+
+        if (error) {
+            reject(nil, nil, error);
+        } else {
+            if (source.redirect) {
+                STPRedirectContext *redirectContext = [[STPRedirectContext alloc] initWithSource:source completion:^(NSString *sourceID, NSString *clientSecret, NSError *error) {
+                    if (error) {
+                        reject(nil, nil, error);
+                    } else {
+                        [[STPAPIClient sharedClient] startPollingSourceWithId:sourceID clientSecret:clientSecret timeout:10 completion:^(STPSource *source, NSError *error) {
+                            if (error) {
+                                reject(nil, nil, error);
+                            } else {
+                                switch (source.status) {
+                                    case STPSourceStatusChargeable:
+                                    case STPSourceStatusConsumed:
+                                        resolve([self convertSourceObject:source]);
+                                        break;
+                                    case STPSourceStatusCanceled:
+                                        reject(
+                                            [NSString stringWithFormat:@"%ld", (long)3],
+                                            @"User cancelled source redirect",
+                                            [[NSError alloc] initWithDomain:@"StripeNative" code:3 userInfo:@{NSLocalizedDescriptionKey:@"User cancelled source redirect"}]
+                                        );
+                                        break;
+                                    case STPSourceStatusPending:
+                                    case STPSourceStatusFailed:
+                                    case STPSourceStatusUnknown:
+                                        reject(
+                                            [NSString stringWithFormat:@"%ld", (long)3],
+                                            @"Source redirect failed",
+                                            [[NSError alloc] initWithDomain:@"StripeNative" code:3 userInfo:@{NSLocalizedDescriptionKey:@"Source redirect failed"}]
+                                        );
+                                        break;
+                                }
+                            }
+                        }];
+                    }
+                }];
+                [redirectContext startSafariAppRedirectFlow];
+            } else {
+                resolve([self convertSourceObject:source]);
+            }
+        }
+    }];
+}
+
 RCT_EXPORT_METHOD(paymentRequestWithCardForm:(NSDictionary *)options
                                     resolver:(RCTPromiseResolveBlock)resolve
                                     rejecter:(RCTPromiseRejectBlock)reject) {
@@ -245,7 +335,6 @@ RCT_EXPORT_METHOD(paymentRequestWithCardForm:(NSDictionary *)options
 
     NSUInteger requiredBillingAddressFields = [self billingType:options[@"requiredBillingAddressFields"]];
     NSString *companyName = options[@"companyName"] ? options[@"companyName"] : @"";
-    BOOL smsAutofillDisabled = [options[@"smsAutofillDisabled"] boolValue];
     STPUserInformation *prefilledInformation = [self userInformation:options[@"prefilledInformation"]];
     NSString *managedAccountCurrency = options[@"managedAccountCurrency"];
     NSString *nextPublishableKey = options[@"publishableKey"] ? options[@"publishableKey"] : publishableKey;
@@ -255,7 +344,6 @@ RCT_EXPORT_METHOD(paymentRequestWithCardForm:(NSDictionary *)options
     STPPaymentConfiguration *configuration = [[STPPaymentConfiguration alloc] init];
     [configuration setRequiredBillingAddressFields:requiredBillingAddressFields];
     [configuration setCompanyName:companyName];
-    [configuration setSmsAutofillDisabled:smsAutofillDisabled];
     [configuration setPublishableKey:nextPublishableKey];
 
 
@@ -290,6 +378,7 @@ RCT_EXPORT_METHOD(paymentRequestWithApplePay:(NSArray *)items
     PKShippingType shippingType = [self applePayShippingType:options[@"shippingType"]];
     NSMutableArray *shippingMethodsItems = options[@"shippingMethods"] ? options[@"shippingMethods"] : [NSMutableArray array];
     NSString* currencyCode = options[@"currencyCode"] ? options[@"currencyCode"] : @"USD";
+    NSString* countryCode = options[@"countryCode"] ? options[@"currencyCode"] : @"US";
 
     NSMutableArray *shippingMethods = [NSMutableArray array];
 
@@ -311,14 +400,13 @@ RCT_EXPORT_METHOD(paymentRequestWithApplePay:(NSArray *)items
         [summaryItems addObject:summaryItem];
     }
 
-    PKPaymentRequest *paymentRequest = [Stripe paymentRequestWithMerchantIdentifier:merchantId];
+    PKPaymentRequest *paymentRequest = [Stripe paymentRequestWithMerchantIdentifier:merchantId country:countryCode currency:currencyCode];
 
     [paymentRequest setRequiredShippingAddressFields:requiredShippingAddressFields];
     [paymentRequest setRequiredBillingAddressFields:requiredBillingAddressFields];
     [paymentRequest setPaymentSummaryItems:summaryItems];
     [paymentRequest setShippingMethods:shippingMethods];
     [paymentRequest setShippingType:shippingType];
-    [paymentRequest setCurrencyCode:currencyCode];
 
     if ([Stripe canSubmitPaymentRequest:paymentRequest]) {
         PKPaymentAuthorizationViewController *paymentAuthorizationVC = [[PKPaymentAuthorizationViewController alloc] initWithPaymentRequest:paymentRequest];
@@ -466,6 +554,119 @@ RCT_EXPORT_METHOD(openApplePaySetup) {
     return result;
 }
 
+- (NSDictionary *)convertSourceObject:(STPSource*)source {
+    NSMutableDictionary *result = [@{} mutableCopy];
+
+    // Source
+    [result setValue:source.clientSecret forKey:@"clientSecret"];
+    [result setValue:@([source.created timeIntervalSince1970]) forKey:@"created"];
+    [result setValue:source.currency forKey:@"currency"];
+    [result setValue:@(source.livemode) forKey:@"livemode"];
+    [result setValue:source.amount forKey:@"amount"];
+
+    // Flow
+    [result setValue:[self sourceFlow:source.flow] forKey:@"flow"];
+
+    // Metadata
+    if (source.metadata) {
+        [result setValue:source.metadata forKey:@"metadata"];
+    }
+
+    // Owner
+    if (source.owner) {
+        NSMutableDictionary *owner = [@{} mutableCopy];
+        [result setValue:owner forKey:@"owner"];
+
+        if (source.owner.address) {
+            [owner setValue:[self address:source.owner.address] forKey:@"address"];
+        }
+        [owner setValue:source.owner.email forKey:@"email"];
+        [owner setValue:source.owner.name forKey:@"name"];
+        [owner setValue:source.owner.phone forKey:@"phone"];
+        if (source.owner.verifiedAddress) {
+            [owner setValue:[self address:source.owner.verifiedAddress] forKey:@"verifiedAddress"];
+        }
+        [owner setValue:source.owner.verifiedEmail forKey:@"verifiedEmail"];
+        [owner setValue:source.owner.verifiedName forKey:@"verifiedName"];
+        [owner setValue:source.owner.verifiedPhone forKey:@"verifiedPhone"];
+    }
+
+    // Details
+    if (source.details) {
+        [result setValue:source.details forKey:@"details"];
+    }
+
+    // Receiver
+    if (source.receiver) {
+        NSMutableDictionary *receiver = [@{} mutableCopy];
+        [result setValue:receiver forKey:@"receiver"];
+
+        [receiver setValue:source.receiver.address forKey:@"address"];
+        [receiver setValue:source.receiver.amountCharged forKey:@"amountCharged"];
+        [receiver setValue:source.receiver.amountReceived forKey:@"amountReceived"];
+        [receiver setValue:source.receiver.amountReturned forKey:@"amountReturned"];
+    }
+
+    // Redirect
+    if (source.redirect) {
+        NSMutableDictionary *redirect = [@{} mutableCopy];
+        [result setValue:redirect forKey:@"redirect"];
+        NSString *returnURL = source.redirect.returnURL.absoluteString;
+        [redirect setValue:returnURL forKey:@"returnURL"];
+        NSString *url = source.redirect.url.absoluteString;
+        [redirect setValue:url forKey:@"url"];
+        [redirect setValue:[self sourceRedirectStatus:source.redirect.status] forKey:@"status"];
+    }
+
+    // Verification
+    if (source.verification) {
+        NSMutableDictionary *verification = [@{} mutableCopy];
+        [result setValue:verification forKey:@"verification"];
+
+        [verification setValue:source.verification.attemptsRemaining forKey:@"attemptsRemaining"];
+        [verification setValue:[self sourceVerificationStatus:source.verification.status] forKey:@"status"];
+    }
+
+    // Status
+    [result setValue:[self sourceStatus:source.status] forKey:@"status"];
+
+    // Type
+    [result setValue:[self sourceType:source.type] forKey:@"type"];
+
+    // Usage
+    [result setValue:[self sourceUsage:source.usage] forKey:@"usage"];
+
+    // CardDetails
+    if (source.cardDetails) {
+        NSMutableDictionary *cardDetails = [@{} mutableCopy];
+        [result setValue:cardDetails forKey:@"cardDetails"];
+
+        [cardDetails setValue:source.cardDetails.last4 forKey:@"last4"];
+        [cardDetails setValue:@(source.cardDetails.expMonth) forKey:@"expMonth"];
+        [cardDetails setValue:@(source.cardDetails.expYear) forKey:@"expYear"];
+        [cardDetails setValue:[self cardBrand:source.cardDetails.brand] forKey:@"brand"];
+        [cardDetails setValue:[self cardFunding:source.cardDetails.funding] forKey:@"funding"];
+        [cardDetails setValue:source.cardDetails.country forKey:@"country"];
+        [cardDetails setValue:[self card3DSecureStatus:source.cardDetails.threeDSecure] forKey:@"threeDSecure"];
+    }
+
+    // SepaDebitDetails
+    if (source.sepaDebitDetails) {
+        NSMutableDictionary *sepaDebitDetails = [@{} mutableCopy];
+        [result setValue:sepaDebitDetails forKey:@"sepaDebitDetails"];
+
+        [sepaDebitDetails setValue:source.sepaDebitDetails.last4 forKey:@"last4"];
+        [sepaDebitDetails setValue:source.sepaDebitDetails.bankCode forKey:@"bankCode"];
+        [sepaDebitDetails setValue:source.sepaDebitDetails.country forKey:@"country"];
+        [sepaDebitDetails setValue:source.sepaDebitDetails.fingerprint forKey:@"fingerprint"];
+        [sepaDebitDetails setValue:source.sepaDebitDetails.mandateReference forKey:@"mandateReference"];
+        NSString *mandateURL = source.sepaDebitDetails.mandateURL.absoluteString;
+        [sepaDebitDetails setValue:mandateURL forKey:@"mandateURL"];
+    }
+
+    return result;
+}
+
 - (NSString *)cardBrand:(STPCardBrand)inputBrand {
     switch (inputBrand) {
         case STPCardBrandJCB:
@@ -495,6 +696,118 @@ RCT_EXPORT_METHOD(openApplePaySetup) {
         case STPCardFundingTypePrepaid:
             return @"prepaid";
         case STPCardFundingTypeOther:
+        default:
+            return @"unknown";
+    }
+}
+
+- (NSString *)card3DSecureStatus:(STPSourceCard3DSecureStatus)inputStatus {
+    switch (inputStatus) {
+        case STPSourceCard3DSecureStatusRequired:
+            return @"required";
+        case STPSourceCard3DSecureStatusOptional:
+            return @"optional";
+        case STPSourceCard3DSecureStatusNotSupported:
+            return @"notSupported";
+        case STPSourceCard3DSecureStatusUnknown:
+        default:
+            return @"unknown";
+    }
+}
+
+- (NSString *)sourceFlow:(STPSourceFlow)inputFlow {
+    switch (inputFlow) {
+        case STPSourceFlowNone:
+            return @"none";
+        case STPSourceFlowRedirect:
+            return @"redirect";
+        case STPSourceFlowCodeVerification:
+            return @"codeVerification";
+        case STPSourceFlowReceiver:
+            return @"receiver";
+        case STPSourceFlowUnknown:
+        default:
+            return @"unknown";
+    }
+}
+
+- (NSString *)sourceRedirectStatus:(STPSourceRedirectStatus)inputStatus {
+    switch (inputStatus) {
+        case STPSourceRedirectStatusPending:
+            return @"pending";
+        case STPSourceRedirectStatusSucceeded:
+            return @"succeeded";
+        case STPSourceRedirectStatusFailed:
+            return @"failed";
+        case STPSourceRedirectStatusUnknown:
+        default:
+            return @"unknown";
+    }
+}
+
+- (NSString *)sourceVerificationStatus:(STPSourceVerificationStatus)inputStatus {
+    switch (inputStatus) {
+        case STPSourceVerificationStatusPending:
+            return @"pending";
+        case STPSourceVerificationStatusSucceeded:
+            return @"succeeded";
+        case STPSourceVerificationStatusFailed:
+            return @"failed";
+        case STPSourceVerificationStatusUnknown:
+        default:
+            return @"unknown";
+    }
+}
+
+- (NSString *)sourceStatus:(STPSourceStatus)inputStatus {
+    switch (inputStatus) {
+        case STPSourceStatusPending:
+            return @"pending";
+        case STPSourceStatusChargeable:
+            return @"chargable";
+        case STPSourceStatusConsumed:
+            return @"consumed";
+        case STPSourceStatusCanceled:
+            return @"canceled";
+        case STPSourceStatusFailed:
+            return @"failed";
+        case STPSourceStatusUnknown:
+        default:
+            return @"unknown";
+    }
+}
+
+- (NSString *)sourceType:(STPSourceType)inputType {
+    switch (inputType) {
+        case STPSourceTypeBancontact:
+            return @"bancontact";
+        case STPSourceTypeBitcoin:
+            return @"bitcoin";
+        case STPSourceTypeGiropay:
+            return @"griopay";
+        case STPSourceTypeIDEAL:
+            return @"ideal";
+        case STPSourceTypeSEPADebit:
+            return @"sepaDebit";
+        case STPSourceTypeSofort:
+            return @"sofort";
+        case STPSourceTypeThreeDSecure:
+            return @"threeDSecure";
+        case STPSourceTypeAlipay:
+            return @"alipay";
+        case STPSourceTypeUnknown:
+        default:
+            return @"unknown";
+    }
+}
+
+- (NSString *)sourceUsage:(STPSourceUsage)inputUsage {
+    switch (inputUsage) {
+        case STPSourceUsageReusable:
+            return @"reusable";
+        case STPSourceUsageSingleUse:
+            return @"singleUse";
+        case STPSourceUsageUnknown:
         default:
             return @"unknown";
     }
@@ -615,9 +928,8 @@ RCT_EXPORT_METHOD(openApplePaySetup) {
 - (STPUserInformation *)userInformation:(NSDictionary*)inputInformation {
     STPUserInformation *userInformation = [[STPUserInformation alloc] init];
 
-    [userInformation setEmail:inputInformation[@"email"]];
-    [userInformation setPhone:inputInformation[@"phone"]];
     [userInformation setBillingAddress: [self address:inputInformation[@"billingAddress"]]];
+    [userInformation setShippingAddress: [self address:inputInformation[@"shippingAddress"]]];
 
     return userInformation;
 }

--- a/scripts/local-ci.sh
+++ b/scripts/local-ci.sh
@@ -27,6 +27,7 @@ files_to_copy=(
   package.json
   index.{ios,android}.js
   android/app/build.gradle
+  ios/example/AppDelegate.m
   src
   scripts
   __tests__
@@ -55,8 +56,6 @@ rm -rf *.tgz
 
 # Create new tarball
 npm pack
-
-tarball_name="$library_name-$library_version.tgz" ./scripts/replaceToTarball.js
 
 if ($skip_new && ! $use_old); then
   echo "Creating new example project skipped"
@@ -91,6 +90,10 @@ else
   # Go to old test project
   cd $proj_dir_old
 fi
+
+tarball_name="$library_name-$library_version.tgz" npm run replace-tarball
+
+npm run set-stripe-url-type
 
 ###################
 # INSTALL         #
@@ -145,6 +148,9 @@ isMacOS && npm run test:ios
 
 if isMacOS; then
   cd ../$proj_dir_podspec
+
+  tarball_name="$library_name-$library_version.tgz" npm run replace-tarball
+  npm run set-stripe-url-type
 
   # Install dependencies
   rm -rf node_modules && npm install

--- a/scripts/post-link-ios.rb
+++ b/scripts/post-link-ios.rb
@@ -7,7 +7,7 @@ require 'fileutils'
 Dir.chdir('ios')
 
 @podfile_path = Pathname.pwd + 'Podfile'
-@pod_dep = "  pod 'Stripe', '~> 10.1.0'\n"
+@pod_dep = "  pod 'Stripe', '~> 11.2.0'\n"
 
 @project_paths= Pathname.pwd.children.select { |pn| pn.extname == '.xcodeproj' }
 raise 'No Xcode project found' unless @project_paths.length > 0

--- a/src/Stripe.ios.js
+++ b/src/Stripe.ios.js
@@ -102,6 +102,15 @@ class Stripe {
     )
     return TPSStripeManager.createTokenWithBankAccount(params)
   }
+
+  createSourceWithParams = (params = {}) => {
+    checkInit(this)
+    checkArgs(
+      types.createSourceWithParamsPropType,
+      params, 'params', 'Stripe.createSourceWithParams'
+    )
+    return TPSStripeManager.createSourceWithParams(params)
+  }
 }
 
 export default new Stripe()

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -22,6 +22,7 @@ export const paymentRequestWithApplePayItemsPropTypes = {
 
 export const paymentRequestWithApplePayOptionsPropTypes = {
   currencyCode: PropTypes.string,
+  countryCode: PropTypes.string,
   requiredBillingAddressFields: PropTypes.arrayOf(PropTypes.oneOf(availableApplePayAddressFields)),
   requiredShippingAddressFields: PropTypes.arrayOf(PropTypes.oneOf(availableApplePayAddressFields)),
   shippingMethods: PropTypes.arrayOf(PropTypes.shape({
@@ -97,4 +98,21 @@ export const paymentRequestWithAndroidPayOptionsPropTypes = {
   currency_code: PropTypes.string.isRequired,
   shipping_address_required: PropTypes.bool,
   line_items: PropTypes.array.isRequired,
+}
+
+export const createSourceWithParamsPropType = {
+  type: PropTypes.oneOf(['bancontact', 'bitcoin', 'griopay', 'ideal', 'sepaDebit', 'sofort', 'threeDSecure', 'alipay']).isRequired,
+  amount: PropTypes.number,
+  name: PropTypes.string,
+  returnURL: PropTypes.string,
+  statementDescriptor: PropTypes.string,
+  currency: PropTypes.string,
+  email: PropTypes.string,
+  bank: PropTypes.string,
+  iban: PropTypes.string,
+  addressLine1: PropTypes.string,
+  city: PropTypes.string,
+  postalCode: PropTypes.string,
+  country: PropTypes.string,
+  card: PropTypes.string,
 }

--- a/tipsi-stripe.podspec
+++ b/tipsi-stripe.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.source_files   = 'ios/TPSStripe/**/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'Stripe', '~> 10.1.0'
+  s.dependency 'Stripe', '~> 11.2.0'
 end


### PR DESCRIPTION
* `STPPaymentConfiguration`: `setSmsAutofillDisabled` has been deprecated
* `PKPaymentRequest`: `paymentRequestWithMerchantIdentifier` added `country` and `currency` params
* `STPUserInformation`: `email` and `phone` have been deprecated in favor of `shippingAddress`

Regarding e2e tests with appium I got stuck when the Safari app is opened with the redirect so you need to manually authorize the transaction once the app opens the Safari browser in order to finish the test.
Here's a demo of the user flow:
![ezgif-1-90721dbd68](https://user-images.githubusercontent.com/5305150/30137085-019fa90e-9362-11e7-9e6b-b934d6e68b60.gif)

