### PR TITLE
[4.0.0] [Breaking Changes] Add supports array of PKAddressFields

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,8 +285,8 @@ _NOTE_: The final item should represent your company; it'll be prepended with th
 
 An object with the following keys:
 
-* `requiredBillingAddressFields` _String_ - A bit field of billing address fields that you need in order to process the transaction. Can be one of: `all`|`name`|`email`|`phone`|`postal_address` or not specify to disable.
-* `requiredShippingAddressFields` _String_ - A bit field of shipping address fields that you need in order to process the transaction. Can be one of: `all`|`name`|`email`|`phone`|`postal_address` or not specify to disable.
+* `requiredBillingAddressFields` _Array\<String\>_ - A bit field of billing address fields that you need in order to process the transaction. Can be one of: `all`|`name`|`email`|`phone`|`postal_address` or not specify to disable.
+* `requiredShippingAddressFields` _Array\<String\>_ - A bit field of shipping address fields that you need in order to process the transaction. Can be one of: `all`|`name`|`email`|`phone`|`postal_address` or not specify to disable.
 * `shippingMethods` _Array_ - An array of `shippingMethod` objects that describe the supported shipping methods.
 * `currencyCode` _String_ - The three-letter ISO 4217 currency code.
 
@@ -351,8 +351,8 @@ const shippingMethods = [{
 }]
 
 const options = {
-  requiredBillingAddressFields: 'all',
-  requiredShippingAddressFields: 'all',
+  requiredBillingAddressFields: ['all'],
+  requiredShippingAddressFields: ['phone', 'postal_address'],
   shippingMethods,
 }
 

--- a/example/src/scenes/ApplePayScreen.js
+++ b/example/src/scenes/ApplePayScreen.js
@@ -64,8 +64,8 @@ export default class ApplePayScreen extends PureComponent {
         label: 'Tipsi',
         amount: '110.00',
       }], {
-        // requiredBillingAddressFields: 'all',
-        // requiredShippingAddressFields: 'all',
+        // requiredBillingAddressFields: ['all'],
+        // requiredShippingAddressFields: ['all'],
         shippingMethods: [{
           id: 'fedex',
           label: 'FedEX',

--- a/ios/TPSStripe/TPSStripeManager.m
+++ b/ios/TPSStripe/TPSStripeManager.m
@@ -557,21 +557,31 @@ RCT_EXPORT_METHOD(openApplePaySetup) {
     return shippingDetails;
 }
 
-- (PKAddressField)applePayAddressFields:(NSString*)inputType {
+- (PKAddressField)applePayAddressFields:(NSArray <NSString *> *)addressFieldStrings {
     PKAddressField addressField = PKAddressFieldNone;
-    if ([inputType isEqualToString:@"postal_address"]) {
+
+    for (NSString *addressFieldString in addressFieldStrings) {
+        addressField |= [self applePayAddressField:addressFieldString];
+    }
+
+    return addressField;
+}
+
+- (PKAddressField)applePayAddressField:(NSString *)addressFieldString {
+    PKAddressField addressField = PKAddressFieldNone;
+    if ([addressFieldString isEqualToString:@"postal_address"]) {
         addressField = PKAddressFieldPostalAddress;
     }
-    if ([inputType isEqualToString:@"phone"]) {
+    if ([addressFieldString isEqualToString:@"phone"]) {
         addressField = PKAddressFieldPhone;
     }
-    if ([inputType isEqualToString:@"email"]) {
+    if ([addressFieldString isEqualToString:@"email"]) {
         addressField = PKAddressFieldEmail;
     }
-    if ([inputType isEqualToString:@"name"]) {
+    if ([addressFieldString isEqualToString:@"name"]) {
         addressField = PKAddressFieldName;
     }
-    if ([inputType isEqualToString:@"all"]) {
+    if ([addressFieldString isEqualToString:@"all"]) {
         addressField = PKAddressFieldAll;
     }
     return addressField;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tipsi-stripe",
-  "version": "3.9.1",
+  "version": "4.0.0",
   "description": "React Native Stripe binding for iOS/Andriod platforms",
   "main": "src/index.js",
   "scripts": {

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -22,8 +22,8 @@ export const paymentRequestWithApplePayItemsPropTypes = {
 
 export const paymentRequestWithApplePayOptionsPropTypes = {
   currencyCode: PropTypes.string,
-  requiredBillingAddressFields: PropTypes.oneOf(availableApplePayAddressFields),
-  requiredShippingAddressFields: PropTypes.oneOf(availableApplePayAddressFields),
+  requiredBillingAddressFields: PropTypes.arrayOf(PropTypes.oneOf(availableApplePayAddressFields)),
+  requiredShippingAddressFields: PropTypes.arrayOf(PropTypes.oneOf(availableApplePayAddressFields)),
   shippingMethods: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,


### PR DESCRIPTION
## Breaking Changes 
There are new types for:
* **`requiredBillingAddressFields`**
* **`requiredShippingAddressFields`**

in `paymentRequestWithApplePay`.

**Before** (3.x) — **_String_**
**Now** (4.x) — **_Array\<String\>_**

#### Old example (3.x)
```js
const options = {
  requiredBillingAddressFields: 'all',
  requiredShippingAddressFields: 'phone',
}
```

#### New example (4.x)
```js
const options = {
  requiredBillingAddressFields: ['all'],
  requiredShippingAddressFields: ['phone', 'postal_address'],
}
```