### PR TITLE
Fix NoClassDefFoundError by bumping to SDK26/Play 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ matrix:
         components:
           - platform-tools
           - tools
-          - build-tools-25.0.0
+          - build-tools-26.0.1
           - android-21
+          - android-26
           - sys-img-armeabi-v7a-android-21
           - extra-android-m2repository
           - extra-google-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ matrix:
       sudo: required
       android:
         components:
+          - tools
           - platform-tools
           - tools
+          - build-tools-25.0.0
           - build-tools-26.0.1
           - android-21
           - android-26

--- a/.travis/before-ci.sh
+++ b/.travis/before-ci.sh
@@ -2,6 +2,7 @@
 
 case "${TRAVIS_OS_NAME}" in
   linux)
+    yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;26.0.1"
     echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a --skin WVGA800
     emulator -avd test -scale 96dpi -dpi-device 160 -no-audio -no-window &
     android-wait-for-emulator

--- a/.travis/before-ci.sh
+++ b/.travis/before-ci.sh
@@ -2,7 +2,6 @@
 
 case "${TRAVIS_OS_NAME}" in
   linux)
-    yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;26.0.1"
     echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a --skin WVGA800
     emulator -avd test -scale 96dpi -dpi-device 160 -no-audio -no-window &
     android-wait-for-emulator

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-  compileSdkVersion 25
-  buildToolsVersion "25.0.0"
+  compileSdkVersion 26
+  buildToolsVersion "26.0.1"
 
   defaultConfig {
     minSdkVersion 16
@@ -24,7 +24,7 @@ dependencies {
   compile 'com.facebook.react:react-native:+'
   compile 'com.android.support:support-v4:25.0.1'
   compile 'com.android.support:appcompat-v7:25.0.1'
-  compile 'com.google.android.gms:play-services-wallet:10.+'
+  compile 'com.google.android.gms:play-services-wallet:11.+'
   compile 'com.stripe:stripe-android:2.1.+'
   compile 'com.github.tipsi:CreditCardEntry:1.4.8.7'
 }


### PR DESCRIPTION
Bumping to RN 0.49.3 meant that we had to upgrade tipsi-stripe from 2.x to 3.x.

This, in turn, meant bumping the build tools to 26.0.1 to match both Lottie and to build Tipsi-Stripe.

The only way for tipsi-stripe to work is to bump the build tools to 26.0.1 and to incorporate the latest play-services-wallet (11.4.2).

This fixes a relapse of issue #18.