### PR TITLE
[4.5.0] Upgrade stripe-android to 6.0.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ dependencies {
   compile 'com.android.support:support-v4:26.1.0'
   compile 'com.android.support:appcompat-v7:26.1.0'
   compile 'com.google.android.gms:play-services-wallet:10.+'
-  compile 'com.stripe:stripe-android:5.1.1'
+  compile 'com.stripe:stripe-android:6.0.0'
   compile 'com.github.tipsi:CreditCardEntry:1.4.8.9'
 }
 


### PR DESCRIPTION
Cause 5.1.1 producing some errors - [similar issue](https://github.com/afollestad/material-dialogs/issues/1469)