### PR TITLE
Added framework search paths

### DIFF
--- a/ios/TPSStripe.xcodeproj/project.pbxproj
+++ b/ios/TPSStripe.xcodeproj/project.pbxproj
@@ -268,6 +268,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"${BUILT_PRODUCTS_DIR}/**",
 					"$BUILD_DIR/$CONFIGURATION$EFFECTIVE_PLATFORM_NAME/Stripe/**",
+					"$(PROJECT_DIR)/../../../ios/Frameworks/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -281,6 +282,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"${BUILT_PRODUCTS_DIR}/**",
 					"$BUILD_DIR/$CONFIGURATION$EFFECTIVE_PLATFORM_NAME/Stripe/**",
+					"$(PROJECT_DIR)/../../../ios/Frameworks/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Hello,

Awesome work! We are not using pods for our project and would there for link the Stipe.framework on our own. There for we added a search path pointing to the parents ios/Framework folder.

Hope this could be approved!