### PR TITLE
[4.6.2] Create namespace for strings on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ dependencies {
   compile 'com.android.support:appcompat-v7:26.1.0'
   compile 'com.google.android.gms:play-services-wallet:10.+'
   compile 'com.stripe:stripe-android:6.0.0'
-  compile 'com.github.tipsi:CreditCardEntry:1.4.8.9'
+  compile 'com.github.tipsi:CreditCardEntry:1.4.8.10'
 }
 
 repositories {

--- a/android/src/main/java/com/gettipsi/stripe/StripeModule.java
+++ b/android/src/main/java/com/gettipsi/stripe/StripeModule.java
@@ -537,7 +537,7 @@ public class StripeModule extends ReactContextBaseJavaModule {
 
   private void androidPayUnavaliableDialog() {
     new AlertDialog.Builder(getCurrentActivity())
-      .setMessage(R.string.android_pay_unavaliable)
+      .setMessage(R.string.gettipsi_android_pay_unavaliable)
       .setPositiveButton(android.R.string.ok, null)
       .show();
   }

--- a/android/src/main/java/com/gettipsi/stripe/dialog/AddCardDialogFragment.java
+++ b/android/src/main/java/com/gettipsi/stripe/dialog/AddCardDialogFragment.java
@@ -78,8 +78,8 @@ public class AddCardDialogFragment extends DialogFragment {
     final View view = View.inflate(getActivity(), R.layout.payment_form_fragment_two, null);
     final AlertDialog dialog = new AlertDialog.Builder(getActivity())
       .setView(view)
-      .setTitle("Enter your card")
-      .setPositiveButton("Done", new DialogInterface.OnClickListener() {
+      .setTitle(R.string.card_enter_dialog_title)
+      .setPositiveButton(R.string.card_enter_dialog_positive_button, new DialogInterface.OnClickListener() {
         @Override
         public void onClick(DialogInterface dialogInterface, int i) {
           onSaveCLick();

--- a/android/src/main/java/com/gettipsi/stripe/dialog/AddCardDialogFragment.java
+++ b/android/src/main/java/com/gettipsi/stripe/dialog/AddCardDialogFragment.java
@@ -78,8 +78,8 @@ public class AddCardDialogFragment extends DialogFragment {
     final View view = View.inflate(getActivity(), R.layout.payment_form_fragment_two, null);
     final AlertDialog dialog = new AlertDialog.Builder(getActivity())
       .setView(view)
-      .setTitle(R.string.card_enter_dialog_title)
-      .setPositiveButton(R.string.card_enter_dialog_positive_button, new DialogInterface.OnClickListener() {
+      .setTitle(R.string.gettipsi_card_enter_dialog_title)
+      .setPositiveButton(R.string.gettipsi_card_enter_dialog_positive_button, new DialogInterface.OnClickListener() {
         @Override
         public void onClick(DialogInterface dialogInterface, int i) {
           onSaveCLick();
@@ -108,7 +108,7 @@ public class AddCardDialogFragment extends DialogFragment {
   @Override
   public void onDismiss(DialogInterface dialog) {
     if (!successful && promise != null) {
-      promise.reject(TAG, getString(R.string.user_cancel_dialog));
+      promise.reject(TAG, getString(R.string.gettipsi_user_cancel_dialog));
       promise = null;
     }
     super.onDismiss(dialog);

--- a/android/src/main/res/layout/payment_form_fragment_two.xml
+++ b/android/src/main/res/layout/payment_form_fragment_two.xml
@@ -43,7 +43,7 @@
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Card"
+        android:text="@string/gettipsi_card_number_label"
         android:paddingLeft="@dimen/activity_horizontal_margin"
         android:paddingRight="@dimen/activity_horizontal_margin"/>
 

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -5,6 +5,8 @@
   <string name="card_cvc">CVC</string>
   <string name="android_pay_unavaliable">Android Pay unavailable on your device.</string>
   <string name="user_cancel_dialog">User cancel dialog. No card added!</string>
+  <string name="card_enter_dialog_title">Enter your card</string>
+  <string name="card_enter_dialog_positive_button">Done</string>
 
   <string-array name="currency_array">
     <item>Currency (optional)</item>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,8 +1,8 @@
 <resources>
 
-  <string name="cardNumber">Card Number</string>
+  <string name="card_number">Card Number</string>
   <string name="save">Save</string>
-  <string name="cvc">CVC</string>
+  <string name="card_cvc">CVC</string>
   <string name="android_pay_unavaliable">Android Pay unavailable on your device.</string>
   <string name="user_cancel_dialog">User cancel dialog. No card added!</string>
 

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,14 +1,14 @@
 <resources>
 
-  <string name="card_number">Card Number</string>
-  <string name="save">Save</string>
-  <string name="card_cvc">CVC</string>
-  <string name="android_pay_unavaliable">Android Pay unavailable on your device.</string>
-  <string name="user_cancel_dialog">User cancel dialog. No card added!</string>
-  <string name="card_enter_dialog_title">Enter your card</string>
-  <string name="card_enter_dialog_positive_button">Done</string>
+  <string name="gettipsi_card_number">Card Number</string>
+  <string name="gettipsi_save">Save</string>
+  <string name="gettipsi_card_cvc">CVC</string>
+  <string name="gettipsi_android_pay_unavaliable">Android Pay unavailable on your device.</string>
+  <string name="gettipsi_user_cancel_dialog">User cancel dialog. No card added!</string>
+  <string name="gettipsi_card_enter_dialog_title">Enter your card</string>
+  <string name="gettipsi_card_enter_dialog_positive_button">Done</string>
 
-  <string-array name="currency_array">
+  <string-array name="gettipsi_currency_array">
     <item>Currency (optional)</item>
     <item>Unspecified</item>
     <item>USD</item>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
   <string name="gettipsi_user_cancel_dialog">User cancel dialog. No card added!</string>
   <string name="gettipsi_card_enter_dialog_title">Enter your card</string>
   <string name="gettipsi_card_enter_dialog_positive_button">Done</string>
+  <string name="gettipsi_card_number_label">Card</string>
 
   <string-array name="gettipsi_currency_array">
     <item>Currency (optional)</item>

--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -21,12 +21,12 @@
     <style name="CardNumber" parent="@style/TextField">
         <item name="android:layout_width">fill_parent</item>
         <item name="android:inputType">numberDecimal</item>
-        <item name="android:hint">@string/cardNumber</item>
+        <item name="android:hint">@string/card_number</item>
     </style>
 
     <style name="CVC" parent="@style/TextField">
         <item name="android:inputType">numberDecimal</item>
-        <item name="android:hint">@string/cvc</item>
+        <item name="android:hint">@string/card_cvc</item>
         <item name="android:layout_width">match_parent</item>
     </style>
 

--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -21,12 +21,12 @@
     <style name="CardNumber" parent="@style/TextField">
         <item name="android:layout_width">fill_parent</item>
         <item name="android:inputType">numberDecimal</item>
-        <item name="android:hint">@string/card_number</item>
+        <item name="android:hint">@string/gettipsi_card_number</item>
     </style>
 
     <style name="CVC" parent="@style/TextField">
         <item name="android:inputType">numberDecimal</item>
-        <item name="android:hint">@string/card_cvc</item>
+        <item name="android:hint">@string/gettipsi_card_cvc</item>
         <item name="android:layout_width">match_parent</item>
     </style>
 
@@ -41,7 +41,7 @@
     <style name="Save" parent="@style/Button">
         <item name="android:layout_width">160dp</item>
         <item name="android:layout_marginTop">8dp</item>
-        <item name="android:text">@string/save</item>
+        <item name="android:text">@string/gettipsi_save</item>
     </style>
 
     <style name="Spinner" parent="@android:style/Widget.Spinner">
@@ -72,7 +72,7 @@
     </style>
 
     <style name="Currency" parent="@style/Spinner">
-        <item name="android:entries">@array/currency_array</item>
+        <item name="android:entries">@array/gettipsi_currency_array</item>
         <item name="android:layout_width">0dp</item>
         <item name="android:layout_weight">1.0</item>
     </style>


### PR DESCRIPTION
This PR adds localization support for Android:
- Move all UI texts to string resources.
- Prefix all string resources with `gettipsi_` to prevent unintended collisions.

As now all UI texts are on string resources, project which uses this lib can override these resources and add e.g. new languages.

Part of the UI texts comes from [CreditCardEntry](https://github.com/tipsi/CreditCardEntry) lib. I made also [PR #4](https://github.com/tipsi/CreditCardEntry/pull/4) for that to move remaining texts to string resources.

When both of these PR's gets merged, resources can be override by adding following strings to project.

```
<!-- tipsi-stripe -->
<string name="gettipsi_card_number">Card Number</string>
<string name="gettipsi_save">Save</string>
<string name="gettipsi_card_cvc">CVC</string>
<string name="gettipsi_android_pay_unavaliable">Android Pay unavailable on your device.</string>
<string name="gettipsi_user_cancel_dialog">User cancel dialog. No card added!</string>
<string name="gettipsi_card_enter_dialog_title">Enter your card</string>
<string name="gettipsi_card_enter_dialog_positive_button">Done</string>
<string name="gettipsi_card_number_label">Card</string>
<string-array name="gettipsi_currency_array">
<item>Currency (optional)</item>
  <item>Unspecified</item>
  <item>USD</item>
</string-array>
  
<!-- CreditCardEntry -->
<string name="ExpirationDateHelp">Expiration date (MM/YY)</string>
<string name="SecurityCodeHelp">Security code (CVV)</string>
<string name="ZipHelp">Zip code of billing address</string>
<string name="SecurityCodeFieldHint">CVV</string>
<string name="ExpDateFieldHint">MM/YY</string>
<string name="ZipCodeFieldHint">   ZIP   </string>
<string name="CreditCardFormCardNumberHint">1234 5678 9012 3456</string>
```