### PR TITLE
[4.6.4] Allow type to be specified on paymentSummaryItems

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ An array of object with the following keys:
 
 * `label` _String_ - A short, localized description of the item.
 * `amount` _String_ - The summary item’s amount.
+* `type` _String_ - The summary item’s type. Must be "pending" or "final". Defaults to "final".
 
 _NOTE_: The final item should represent your company; it'll be prepended with the word "Pay" (i.e. "Pay Tipsi, Inc $50")
 

--- a/ios/TPSStripe/TPSStripeManager.m
+++ b/ios/TPSStripe/TPSStripeManager.m
@@ -406,6 +406,7 @@ RCT_EXPORT_METHOD(paymentRequestWithApplePay:(NSArray *)items
         PKPaymentSummaryItem *summaryItem = [[PKPaymentSummaryItem alloc] init];
         summaryItem.label = item[@"label"];
         summaryItem.amount = [NSDecimalNumber decimalNumberWithString:item[@"amount"]];
+        summaryItem.type = [@"pending" isEqualToString:item[@"type"]] ? PKPaymentSummaryItemTypePending : PKPaymentSummaryItemTypeFinal;
         [summaryItems addObject:summaryItem];
     }
 
@@ -425,7 +426,7 @@ RCT_EXPORT_METHOD(paymentRequestWithApplePay:(NSArray *)items
         // There is a problem with your Apple Pay configuration.
         [self resetPromiseCallbacks];
         requestIsCompleted = YES;
-        
+
         NSError *error = [TPSError applePayNotConfiguredError];
         reject([NSString stringWithFormat:@"%ld", error.code], error.localizedDescription, error);
     }
@@ -539,7 +540,7 @@ RCT_EXPORT_METHOD(openApplePaySetup) {
     void(^completion)() = ^{
         if (!requestIsCompleted) {
             requestIsCompleted = YES;
-            
+
             [self rejectPromiseWithError:[TPSError userCancelError]];
         } else {
             if (applePayStripeError) {
@@ -550,7 +551,7 @@ RCT_EXPORT_METHOD(openApplePaySetup) {
             }
         }
     };
-    
+
     [RCTPresentedViewController() dismissViewControllerAnimated:YES completion:completion];
 }
 

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -17,6 +17,7 @@ export const paymentRequestWithApplePayItemsPropTypes = {
   items: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.string.isRequired,
     amount: PropTypes.string.isRequired,
+    type: PropTypes.oneOf('final', 'pending'),
   })),
 }
 


### PR DESCRIPTION
You can specify `pending`, otherwise it'll be set to `final`

Apple documentation: https://developer.apple.com/documentation/passkit/pkpaymentsummaryitem