### PR TITLE
Fix "oneOf" warning

### DIFF
--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -17,7 +17,7 @@ export const paymentRequestWithApplePayItemsPropTypes = {
   items: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.string.isRequired,
     amount: PropTypes.string.isRequired,
-    type: PropTypes.oneOf('final', 'pending'),
+    type: PropTypes.oneOf(['final', 'pending']),
   })),
 }
 


### PR DESCRIPTION
PropTypes.oneOf expects an array for enums