### PR TITLE
Ensure compatibility for Firebase and Google Play Services

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,8 +26,14 @@ android {
 }
 
 dependencies {
-  def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
-  def firebaseCoreVersion = project.hasProperty('firebaseCoreVersion') ? project.firebaseCoreVersion : DEFAULT_FIREBASE_CORE_VERSION
+  def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion')
+    ? project.googlePlayServicesVersion
+    : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
+
+  def firebaseCoreVersion = project.hasProperty('firebaseCoreVersion')
+    ? project.firebaseCoreVersion
+    : DEFAULT_FIREBASE_CORE_VERSION
+
   compile fileTree(include: ['*.jar'], dir: 'libs')
   compile 'com.facebook.react:react-native:+'
   compile 'com.android.support:support-v4:26.1.0'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'com.android.library'
 
+def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION = "11.8.+";
+def DEFAULT_FIREBASE_CORE_VERSION = "11.8.+";
+
 android {
   compileSdkVersion 26
   buildToolsVersion '26.0.2'
@@ -23,12 +26,14 @@ android {
 }
 
 dependencies {
+  def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
+  def firebaseCoreVersion = project.hasProperty('firebaseCoreVersion') ? project.firebaseCoreVersion : DEFAULT_FIREBASE_CORE_VERSION
   compile fileTree(include: ['*.jar'], dir: 'libs')
   compile 'com.facebook.react:react-native:+'
   compile 'com.android.support:support-v4:26.1.0'
   compile 'com.android.support:appcompat-v7:26.1.0'
-  compile 'com.google.android.gms:play-services-wallet:11.8.0'
-  compile 'com.google.firebase:firebase-core:11.8.0'
+  compile "com.google.android.gms:play-services-wallet:$googlePlayServicesVersion"
+  compile "com.google.firebase:firebase-core:$firebaseCoreVersion"
   compile 'com.stripe:stripe-android:6.0.0'
   compile 'com.github.tipsi:CreditCardEntry:1.4.8.10'
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -89,6 +89,9 @@ def enableSeparateBuildPerCPUArchitecture = false
  */
 def enableProguardInReleaseBuilds = false
 
+def googlePlayServicesVersion = project.googlePlayServicesVersion
+def firebaseCoreVersion = project.firebaseCoreVersion
+
 android {
     compileSdkVersion 26
     buildToolsVersion "26.0.2"

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -19,3 +19,5 @@
 
 android.useDeprecatedNdk=true
 android.enableAapt2=false
+googlePlayServicesVersion=15.0.1
+firebaseCoreVersion=16.0.0


### PR DESCRIPTION
@isnifer this change is necessary to support future versions of Firebase and Google Play Services.
In my project I used to have:
```
compile ('com.google.android.gms:play-services-gcm:15.+') {
    force = true;
}
```
to override Google Play services, but now I don't use that module anymore.
I think it is neater to add

```
// gradle.properties
googlePlayServicesVersion=15.0.1
```

For context:
https://github.com/rebeccahughes/react-native-device-info/issues/187

https://github.com/rebeccahughes/react-native-device-info/blob/e2c877f461c4181113abb3ff8f6bb8dfe89de0fb/android/build.gradle#L26-L31

If you agree with this change I can update the readme as well