### PR TITLE
[5.2.3] Remove package.json from preseve_paths in Podspec

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tipsi-stripe",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "React Native Stripe binding for iOS/Andriod platforms",
   "main": "src/index.js",
   "scripts": {

--- a/tipsi-stripe.podspec
+++ b/tipsi-stripe.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.requires_arc   = true
   s.platform       = :ios, '8.0'
 
-  s.preserve_paths = 'LICENSE', 'README.md', 'package.json'
+  s.preserve_paths = 'LICENSE', 'README.md'
   s.source_files   = 'ios/TPSStripe/**/*.{h,m}'
 
   s.dependency 'React'


### PR DESCRIPTION
Hello! We're trying to integrate this library with [artsy/emission](https://github.com/artsy/emission), which is an ios react-native component library.  We ran into the following issue when we added this package:
 
```
[0] error: bundling failed: Error: While trying to resolve module `tipsi-stripe` from file `/Users/eriks/dev/artsy/emission/src/lib/Components/Bidding/Screens/ConfirmFirstTimeBid.tsx`, the package `/Users/eriks/dev/artsy/emission/Example/Pods/tipsi-stripe/package.json` was successfully found. However, this package itself specifies a `main` module field that could not be resolved (`/Users/eriks/dev/artsy/emission/Example/Pods/tipsi-stripe/src/index.js`. Indeed, none of these files exist:
```

On inspection it seemed that node resolved the tipsi-stripe module to the cocoapods directory instead of the root `node_modules` directory- I think this is because we are trying to use this in a component library- we also set up our [Podfile](https://github.com/artsy/emission/blob/51e1a1f6bdce3f5463d89053a1d518fd0b573f21/Example/Podfile#L55) with a link pointing directly to the tipsi-stripe node module rather than dragging the folder into the Xcode project.

Removing package.json from the `/Pods/tipsi-stripe` folder in our Example storybook app fixed the issue. We don't anticipate any other adverse consequences from this (here is a link to the [cocoapods documentation](https://guides.cocoapods.org/syntax/podspec.html).

Looking forward to your thoughts & feedback- thanks!
