### PR TITLE
feat: Updates for RN 0.55+ and latest Stripe

### DIFF
--- a/.travis/before-install.sh
+++ b/.travis/before-install.sh
@@ -18,7 +18,6 @@ init_new_example_project() {
     src
     scripts
     __tests__
-    ios/Podfile
   )
 
   mkdir tmp

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,6 +9,7 @@ android {
     targetSdkVersion 26
     versionCode 1
     versionName "1.0"
+    multiDexEnabled true
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     manifestPlaceholders = [
       tipsiStripeRedirectScheme: "example"
@@ -27,8 +28,23 @@ dependencies {
   compile 'com.facebook.react:react-native:+'
   compile 'com.android.support:support-v4:26.1.0'
   compile 'com.android.support:appcompat-v7:26.1.0'
-  compile 'com.google.android.gms:play-services-wallet:11.8.0'
-  compile 'com.google.firebase:firebase-core:11.8.0'
+  compile 'com.android.support:design:27.1.0'
+  // compile 'com.google.android.gms:play-services-wallet:11.8.0'
+  // compile 'com.google.firebase:firebase-core:11.8.0'
+  // compile 'com.google.android.gms:play-services-wallet:11.8.0' {
+  //   force = true;
+  // } 
+  // compile 'com.google.firebase:firebase-core:11.8.0' {
+  //   force = true;
+  // }
+  // compile 'com.google.android.gms:play-services-wallet:+'
+  // compile 'com.google.firebase:firebase-core:+'
+  compile ('com.google.android.gms:play-services-wallet:+') {
+    force = true;
+  }
+  compile ('com.google.firebase:firebase-core:+') {
+    force = true;
+  }
   compile 'com.stripe:stripe-android:6.0.0'
   compile 'com.github.tipsi:CreditCardEntry:1.4.8.10'
 }

--- a/ios/TPSStripe.xcodeproj/project.pbxproj
+++ b/ios/TPSStripe.xcodeproj/project.pbxproj
@@ -268,6 +268,15 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"${BUILT_PRODUCTS_DIR}/**",
 					"$BUILD_DIR/$CONFIGURATION$EFFECTIVE_PLATFORM_NAME/Stripe/**",
+					"${SRCROOT}/../../../ios/Frameworks/Stripe/**",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../../../React/**",
+					"$(SRCROOT)/../../react-native/React/**",
+					"${SRCROOT}/../../../ios/Pods/Headers/Public",
+					"${SRCROOT}/../../../ios/Pods/Headers/Public/Stripe",
+					"${SRCROOT}/../../../ios/Frameworks/Stripe/**",
+					"${SRCROOT}/../../../ios/Frameworks/Stripe/Stripe.framework/Versions/A/Headers/Public/Stripe",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -281,6 +290,15 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"${BUILT_PRODUCTS_DIR}/**",
 					"$BUILD_DIR/$CONFIGURATION$EFFECTIVE_PLATFORM_NAME/Stripe/**",
+					"${SRCROOT}/../../../ios/Frameworks/Stripe/**",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../../../React/**",
+					"$(SRCROOT)/../../react-native/React/**",
+					"${SRCROOT}/../../../ios/Pods/Headers/Public",
+					"${SRCROOT}/../../../ios/Pods/Headers/Public/Stripe",
+					"${SRCROOT}/../../../ios/Frameworks/Stripe/**",
+					"${SRCROOT}/../../../ios/Frameworks/Stripe/Stripe.framework/Versions/A/Headers/Public/Stripe",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ios/TPSStripe/TPSCardField.h
+++ b/ios/TPSStripe/TPSCardField.h
@@ -8,7 +8,8 @@
 
 #import <React/UIView+React.h>
 
-@import Stripe
+@import Stripe;
+//#import "Stripe/Stripe.h"
 
 @interface TPSCardField : UIView
 

--- a/ios/TPSStripe/TPSCardField.h
+++ b/ios/TPSStripe/TPSCardField.h
@@ -7,7 +7,8 @@
 //
 
 #import <React/UIView+React.h>
-#import <Stripe/Stripe.h>
+
+@import Stripe
 
 @interface TPSCardField : UIView
 

--- a/ios/TPSStripe/TPSStripeManager.h
+++ b/ios/TPSStripe/TPSStripeManager.h
@@ -8,9 +8,10 @@
 
 #import <Foundation/Foundation.h>
 #import <PassKit/PassKit.h>
-#import <Stripe/Stripe.h>
 #import <React/RCTBridgeModule.h>
 #import <React/RCTConvert.h>
+
+@import Stripe
 
 @interface TPSStripeManager : NSObject <RCTBridgeModule, PKPaymentAuthorizationViewControllerDelegate, STPAddCardViewControllerDelegate>
 

--- a/ios/TPSStripe/TPSStripeManager.h
+++ b/ios/TPSStripe/TPSStripeManager.h
@@ -8,10 +8,9 @@
 
 #import <Foundation/Foundation.h>
 #import <PassKit/PassKit.h>
+#import <Stripe/Stripe.h>
 #import <React/RCTBridgeModule.h>
 #import <React/RCTConvert.h>
-
-@import Stripe
 
 @interface TPSStripeManager : NSObject <RCTBridgeModule, PKPaymentAuthorizationViewControllerDelegate, STPAddCardViewControllerDelegate>
 

--- a/ios/TPSStripe/TPSStripeManager.m
+++ b/ios/TPSStripe/TPSStripeManager.m
@@ -255,9 +255,9 @@ RCT_EXPORT_METHOD(createSourceWithParams:(NSDictionary *)params
     if ([sourceType isEqualToString:@"bancontact"]) {
          sourceParams = [STPSourceParams bancontactParamsWithAmount:[[params objectForKey:@"amount"] unsignedIntegerValue] name:params[@"name"] returnURL:params[@"returnURL"] statementDescriptor:params[@"statementDescriptor"]];
     }
-    if ([sourceType isEqualToString:@"bitcoin"]) {
-         sourceParams = [STPSourceParams bitcoinParamsWithAmount:[[params objectForKey:@"amount"] unsignedIntegerValue] currency:params[@"currency"] email:params[@"email"]];
-    }
+//    if ([sourceType isEqualToString:@"bitcoin"]) {
+//         sourceParams = [STPSourceParams bitcoinParamsWithAmount:[[params objectForKey:@"amount"] unsignedIntegerValue] currency:params[@"currency"] email:params[@"email"]];
+//    }
     if ([sourceType isEqualToString:@"giropay"]) {
          sourceParams = [STPSourceParams giropayParamsWithAmount:[[params objectForKey:@"amount"] unsignedIntegerValue] name:params[@"name"] returnURL:params[@"returnURL"] statementDescriptor:params[@"statementDescriptor"]];
     }
@@ -842,8 +842,8 @@ RCT_EXPORT_METHOD(openApplePaySetup) {
     switch (inputType) {
         case STPSourceTypeBancontact:
             return @"bancontact";
-        case STPSourceTypeBitcoin:
-            return @"bitcoin";
+//        case STPSourceTypeBitcoin:
+//            return @"bitcoin";
         case STPSourceTypeGiropay:
             return @"giropay";
         case STPSourceTypeIDEAL:


### PR DESCRIPTION
This PR is for those of you would would rather manually install the latest Stripe framework (without cocoapods).  This was written and worked with RN 0.55 and Stripe 13.0.3.

1) Manually install the iOS "Dynamic Framework"
https://github.com/stripe/stripe-ios/releases/tag/v13.0.3

Introductions:
https://stripe.com/docs/mobile/ios

![ios_integration](https://user-images.githubusercontent.com/367806/41378802-16f5f9ea-6f15-11e8-9a3c-81e706523a48.png)

2) Add the PR branch to your package.json
```
"tipsi-stripe": "FreebirdRides/tipsi-stripe#master",
```

```
yarn add FreebirdRides/tipsi-stripe#master
```
3) react-native link

4) Good luck!

