### PR TITLE
[5.2.4] Add missing placeholder fields to iOS <PaymentCardTextField />

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,22 @@
 # Changelog
 
-## [5.2.0] - 2018-04-04
+## [5.2.4] - 2018-06-28
+### Added
+- Added missing `{number|expiration|cvc}Placeholder` fields to iOS' `<PaymentCardTextField />`
 
+## [5.2.3] - 2018-06-07
+### Changed
+- Removed `package.json` from tipsi-stripe's podspec `preserve_paths` (to enable adding this pod via a `:git` key without hitting npm/yarn considering it a js package)
+
+## [5.2.2] - 2018-06-01
+### Changed
+- Fixed int LOAD_PAYMENT_DATA_REQUEST_CODE in GoogleApiPayFlowImpl.java (< 65535)
+
+## [5.2.1] - 2018-05-05
+### Added
+- Fixed an error with PropTypes
+
+## [5.2.0] - 2018-04-04
 ### Added 
 - Method `stripe.canMakeAndroidPayPayments()` checks if gpay supported and user has existing payment method
 
@@ -9,12 +24,10 @@
 - Method `stripe.deviceSupportsAndroidPay()` doesn’t require anymore user to have existing payment method
 
 ## [5.1.0] - 2018-03-28
-
 ### Changed
 - Method `deviceSupportAndroidPay()` now also checks if google pay has at least one existing payment method (for example user attached his card before)
 
 ## [5.0.0] - 2018-03-21
-
 ### Breaking changes:
 
 #### 1) Initialization

--- a/example/__tests__/05_test_card_text_field.js
+++ b/example/__tests__/05_test_card_text_field.js
@@ -6,18 +6,22 @@ const { driver, select, idFromAccessId, idFromResourceId } = helper
 
 test('Test if user can use PaymentCardTextField component', async (t) => {
   const cardTextFieldId = idFromAccessId('cardTextField')
-  const inputNumber = select({
+
+  const placeholderId = select({
     ios: idFromAccessId('card number'),
-    android: idFromResourceId('com.example:id/cc_four_digits'),
+    android: idFromResourceId('com.example:id/cc_card'),
   })
+
   const inputExpData = select({
     ios: idFromAccessId('expiration date'),
     android: idFromResourceId('com.example:id/cc_exp'),
   })
+
   const inputCVC = select({
     ios: idFromAccessId('CVC'),
     android: idFromResourceId('com.example:id/cc_ccv'),
   })
+
   const cardPramIds = {
     valid: idFromAccessId('paramValid'),
     number: idFromAccessId('paramNumber'),
@@ -29,21 +33,40 @@ test('Test if user can use PaymentCardTextField component', async (t) => {
   await openTestSuite('Card Text Field')
 
   await driver.waitForVisible(cardTextFieldId, 15000)
-
   t.pass('User should see `PaymentCardTextField` component')
 
-  await driver.click(cardTextFieldId)
+  /*
+    Custom Placeholders:
 
+    numberPlaceholder="XXXX XXXX XXXX XXXX"
+    expirationPlaceholder="MM/YY"
+    cvcPlaceholder="123"
+  */
+  const placeholder = await driver.getText(placeholderId)
+  t.equal(placeholder, 'XXXX XXXX XXXX XXXX', 'Custom placeholder as expected')
+
+  await driver.click(cardTextFieldId)
   t.pass('User should be able focus on `PaymentCardTextField` component')
 
-  await driver.keys('4242424242424242 1234 123')
-  await driver.waitForVisible(inputNumber, 50000).waitForText(inputNumber)
-  await driver.waitForVisible(inputExpData, 50000).waitForText(inputExpData)
-  await driver.waitForVisible(inputCVC, 50000).waitForText(inputCVC)
+  // Set card number
+  await driver.keys('4242424242424242')
 
+  // Set expiration date
+  await driver.waitForVisible(inputExpData, 50000)
+  await driver.keys('1234')
+  await driver.waitForText(inputExpData)
+
+  // Set cvc
+  await driver.waitForVisible(inputCVC, 50000)
+  await driver.keys('123')
+  await driver.waitForText(inputCVC)
   t.pass('User should be able write card data on `PaymentCardTextField` component')
 
-  t.equal(await driver.getText(cardPramIds.number), 'Number: 4242424242424242', 'Number should be 4242424242424242')
+  t.equal(
+    await driver.getText(cardPramIds.number),
+    'Number: 4242424242424242',
+    'Number should be 4242424242424242'
+  )
   t.equal(await driver.getText(cardPramIds.expMonth), 'Month: 12', 'Month should be 12')
   t.equal(await driver.getText(cardPramIds.expYear), 'Year: 34', 'Year should be 34')
   t.equal(await driver.getText(cardPramIds.cvc), 'CVC: 123', 'CVC should be 123')

--- a/example/scripts/build-android.sh
+++ b/example/scripts/build-android.sh
@@ -19,6 +19,8 @@ keytool \
   -storepass android \
   -alias androidreleasekey \
   -keypass android \
+  -keysize 1024 \
+  -validity 14000 \
   -dname 'CN=Android Debug,O=Android,C=US'
 
 # Run release build

--- a/example/src/scenes/CardTextFieldScreen.js
+++ b/example/src/scenes/CardTextFieldScreen.js
@@ -47,6 +47,9 @@ export default class CardTextFieldScreen extends PureComponent {
             accessible={false}
             style={styles.field}
             onParamsChange={this.handleFieldParamsChange}
+            numberPlaceholder="XXXX XXXX XXXX XXXX"
+            expirationPlaceholder="MM/YY"
+            cvcPlaceholder="CVC"
             {...testID('cardTextField')}
           />
           <Spoiler title="Params" style={styles.spoiler}>

--- a/ios/TPSStripe/TPSCardField.m
+++ b/ios/TPSStripe/TPSCardField.m
@@ -136,6 +136,30 @@
     _paymentCardTextField.textErrorColor = textErrorColor;
 }
 
+- (NSString *)numberPlaceholder {
+    return _paymentCardTextField.numberPlaceholder;
+}
+
+- (void)setNumberPlaceholder:(NSString *)numberPlaceholder {
+    _paymentCardTextField.numberPlaceholder = numberPlaceholder;
+}
+
+- (NSString *)expirationPlaceholder {
+    return _paymentCardTextField.expirationPlaceholder;
+}
+
+- (void)setExpirationPlaceholder:(NSString *)placeholder {
+    _paymentCardTextField.expirationPlaceholder = placeholder;
+}
+
+- (NSString *)cvcPlaceholder {
+    return _paymentCardTextField.cvcPlaceholder;
+}
+
+- (void)setCvcPlaceholder:(NSString *)cvcPlaceholder {
+    _paymentCardTextField.cvcPlaceholder = cvcPlaceholder;
+}
+
 - (UIColor *)placeholderColor {
     return _paymentCardTextField.placeholderColor;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tipsi-stripe",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "description": "React Native Stripe binding for iOS/Andriod platforms",
   "main": "src/index.js",
   "scripts": {

--- a/scripts/local-ci.sh
+++ b/scripts/local-ci.sh
@@ -166,7 +166,7 @@ if isMacOS; then
   npm run configure
 
   # Build iOS app
-  npm run build:ios
+  npm run build:ios | xcpretty
 
   # Run iOS e2e tests
   npm run test:ios


### PR DESCRIPTION
Fixes #284  
Following the pattern of the rest of this component, this pr adds accessor methods to the TPSCardField.m which simply forward these properties onto the  Stripe SDK field.
