### PR TITLE
Respect project-level GMS version on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,18 @@
 apply plugin: 'com.android.library'
 
+def DEFAULT_COMPILE_SDK_VERSION             = 26
+def DEFAULT_TARGET_SDK_VERSION              = 26
+def DEFAULT_BUILD_TOOLS_VERSION             = '26.0.2'
+def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION    = '11.8.0'
+def DEFAULT_FIREBASE_MESSAGING_VERSION      = '11.8.0'
+
 android {
-  compileSdkVersion 26
-  buildToolsVersion '26.0.2'
+  compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
+  buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 
   defaultConfig {
     minSdkVersion 16
-    targetSdkVersion 26
+    targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
     versionCode 1
     versionName "1.0"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -23,12 +29,15 @@ android {
 }
 
 dependencies {
+  def firebaseVersion = project.hasProperty('firebaseVersion') ? project.firebaseVersion : DEFAULT_FIREBASE_MESSAGING_VERSION
+  def googlePlayServicesVersion = rootProject.hasProperty('googlePlayServicesVersion')  ? rootProject.googlePlayServicesVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
+
   compile fileTree(include: ['*.jar'], dir: 'libs')
   compile 'com.facebook.react:react-native:+'
   compile 'com.android.support:support-v4:26.1.0'
   compile 'com.android.support:appcompat-v7:26.1.0'
-  compile 'com.google.android.gms:play-services-wallet:11.8.0'
-  compile 'com.google.firebase:firebase-core:11.8.0'
+  compile "com.google.android.gms:play-services-wallet:$googlePlayServicesVersion"
+  compile "com.google.firebase:firebase-core:$firebaseVersion"
   compile 'com.stripe:stripe-android:6.0.0'
   compile 'com.github.tipsi:CreditCardEntry:1.4.8.10'
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -34,3 +34,9 @@ allprojects {
         }
     }
 }
+
+ext {
+    buildToolsVersion = "26.0.2"
+    firebaseVersion = "11.8.0"
+    googlePlayServicesVersion = "11.8.0"
+}


### PR DESCRIPTION
Hard-coding a GCM version makes it impossible to compile on Android project that uses different GCM or firebase version.

This seems to be a new trend in Android dependencies  to solve dependency conflict for GCM and Firebase. See [react-native-google-places](https://github.com/tolu360/react-native-google-places/blob/8ead774b6a6785580b1a7214f1a9b98b1ef635ef/android/build.gradle) and [react-native-push-notification](https://github.com/zo0r/react-native-push-notification/blob/a071458feafc80a7a23cc43258d43f645833c0e9/android/build.gradle) for example

This change is non-breaking because it still uses the older versions as fallback. No project could've defined a different version and used tipsi-stripe (as the compilation would've failed anyway because of a dep conflict).