### PR TITLE
Fix docs' link to Podfile example

### DIFF
--- a/docs/docs/installation.html
+++ b/docs/docs/installation.html
@@ -10,7 +10,7 @@
 <pre><code class="hljs">yarn <span class="hljs-keyword">add</span><span class="bash"> tipsi-stripe
 </span></code></pre>
 <h3><a class="anchor" aria-hidden="true" id="cocoapods-ios"></a><a href="#cocoapods-ios" aria-hidden="true" class="hash-link" ><svg aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg></a>CocoaPods (iOS)</h3>
-<p>Setup your <code>Podfile</code> like the included <a href="https://github.com/tipsi/tipsi-stripe/blob/master/example/ios/Podfile"><a href="example/ios/Podfile">example/ios/Podfile</a></a> then run <code>pod install</code>.</p>
+<p>Setup your <code>Podfile</code> like the included <a href="https://github.com/tipsi/tipsi-stripe/blob/master/example/ios/Podfile">example/ios/Podfile</a> then run <code>pod install</code>.</p>
 <ol>
 <li>Open your project in Xcode workspace.</li>
 <li>Drag the following folder into your project:


### PR DESCRIPTION
## Proposed changes
The link to the Podfile doesn't work (there's another <a> inside the first one).
