### PR TITLE
Remove prop-types

### DIFF
--- a/src/components/PaymentCardTextField.js
+++ b/src/components/PaymentCardTextField.js
@@ -5,65 +5,12 @@ import {
   StyleSheet,
   View,
   TouchableWithoutFeedback,
-  ViewPropTypes,
-  Platform,
+  TextInput,
 } from 'react-native'
-import PropTypes from 'prop-types'
-import StyleSheetPropType from 'react-native/Libraries/StyleSheet/StyleSheetPropType'
-import ViewStylePropTypes from 'react-native/Libraries/Components/View/ViewStylePropTypes'
-import TextInputState from 'react-native/Libraries/Components/TextInput/TextInputState'
 
-const FieldStylePropType = {
-  ...ViewStylePropTypes,
-  color: PropTypes.string,
-}
-
-const NativePaymentCardTextField = requireNativeComponent('TPSCardField', PaymentCardTextField, {
-  nativeOnly: {
-    borderColor: true,
-    borderWidth: true,
-    cornerRadius: true,
-    textColor: true,
-    fontFamily: true,
-    fontWeight: true,
-    fontStyle: true,
-    fontSize: true,
-    enabled: true,
-    onChange: true,
-    params: true, // Currently iOS only
-    keyboardAppearance: true, // iOS only
-  },
-})
+const NativePaymentCardTextField = requireNativeComponent('TPSCardField', PaymentCardTextField)
 
 export default class PaymentCardTextField extends Component {
-  static propTypes = {
-    ...ViewPropTypes,
-    style: StyleSheetPropType(FieldStylePropType), // eslint-disable-line new-cap
-
-    // Common
-    expirationPlaceholder: PropTypes.string,
-    numberPlaceholder: PropTypes.string,
-    cvcPlaceholder: PropTypes.string,
-    disabled: PropTypes.bool,
-    onChange: PropTypes.func,
-
-    ...Platform.select({
-      ios: {
-        cursorColor: PropTypes.string,
-        textErrorColor: PropTypes.string,
-        placeholderColor: PropTypes.string,
-        keyboardAppearance: PropTypes.oneOf(['default', 'light', 'dark']),
-      },
-      android: {
-        setEnabled: PropTypes.bool,
-        backgroundColor: PropTypes.string,
-        cardNumber: PropTypes.string,
-        expDate: PropTypes.string,
-        securityCode: PropTypes.string,
-      },
-    }),
-  }
-
   static defaultProps = {
     ...View.defaultProps,
   }
@@ -83,15 +30,15 @@ export default class PaymentCardTextField extends Component {
   }
 
   isFocused = () => (
-    TextInputState.currentlyFocusedField() === findNodeHandle(this.cardTextFieldRef)
+    TextInput.State.currentlyFocusedField() === findNodeHandle(this.cardTextFieldRef)
   )
 
   focus = () => {
-    TextInputState.focusTextInput(findNodeHandle(this.cardTextFieldRef))
+    TextInput.State.focusTextInput(findNodeHandle(this.cardTextFieldRef))
   }
 
   blur = () => {
-    TextInputState.blurTextInput(findNodeHandle(this.cardTextFieldRef))
+    TextInput.State.blurTextInput(findNodeHandle(this.cardTextFieldRef))
   }
 
   handlePress = () => {


### PR DESCRIPTION
## Proposed changes
React Native is removing prop types from core components so this breaks some of the usages here. I decided to just get rid of prop types altogether instead of trying to add them back somehow. The community seems to be moving towards static typing instead of those runtime checks.

See facebook/react-native#21342

Also updated the private `TextInputState` import with `TextInput.State` and removed `nativeOnly` from `requireNativeComponent` since recent versions of RN no longer check this (https://github.com/facebook/react-native/blob/master/Libraries/ReactNative/requireNativeComponent.js#L24).

## Types of changes
What types of changes does your code introduce to `tipsi-stripe`?  
_Put an `x` in the boxes that apply_

Not really a bugfix but should not be a breaking change and removed  `requireNativeComponent`

- [x] Bugfix (a non-breaking change which fixes an issue)  
- [ ] New feature (a non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! Next steps are a reminder of what we are going to look at before merging your code._

N/A - Tested manually

- [ ] I have added tests that prove my fix is useful or that my feature works  
- [ ] I have added necessary documentation (if appropriate)  
- [ ] I know that my PR will be merged only if it has tests and they pass  

