### PR TITLE
assigned promiseRejector in api calls to createTokenWithBankAccount a…

### DIFF
--- a/ios/TPSStripe/TPSStripeManager.m
+++ b/ios/TPSStripe/TPSStripeManager.m
@@ -188,6 +188,7 @@ RCT_EXPORT_METHOD(createTokenWithCard:(NSDictionary *)params
     }
 
     requestIsCompleted = NO;
+    promiseRejector = reject;
 
     STPCardParams *cardParams = [[STPCardParams alloc] init];
 
@@ -229,6 +230,7 @@ RCT_EXPORT_METHOD(createTokenWithBankAccount:(NSDictionary *)params
     }
 
     requestIsCompleted = NO;
+    promiseRejector = reject;
 
     STPBankAccountParams *bankAccount = [[STPBankAccountParams alloc] init];
 


### PR DESCRIPTION
## Proposed changes
Fixes for the createTokenWithBankAccount and createTokenWithCard. These two methods currently fail silently because the rejection block is not assigned. 


## Types of changes
What types of changes does your code introduce to `tipsi-stripe`?  
_Put an `x` in the boxes that apply_

- [x] Bugfix (a non-breaking change which fixes an issue)  
- [ ] New feature (a non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

## Checklist
- [] I have added tests that prove my fix is useful or that my feature works  
- [x] I have added necessary documentation (if appropriate)  
- [x] I know that my PR will be merged only if it has tests and they pass  
