### PR TITLE
Fix: STPAddCardViewController disappear immediately after is being presented.

### DIFF
--- a/ios/TPSStripe/TPSStripeManager.m
+++ b/ios/TPSStripe/TPSStripeManager.m
@@ -384,7 +384,12 @@ RCT_EXPORT_METHOD(paymentRequestWithCardForm:(NSDictionary *)options
     UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:addCardViewController];
     [navigationController setModalPresentationStyle:formPresentation];
     navigationController.navigationBar.stp_theme = theme;
-    [RCTPresentedViewController() presentViewController:navigationController animated:YES completion:nil];
+    // move to the end of main queue
+    // allow the execution of hiding modal
+    // to be finished first
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [RCTPresentedViewController() presentViewController:navigationController animated:YES completion:nil];
+    });
 }
 
 RCT_EXPORT_METHOD(paymentRequestWithApplePay:(NSArray *)items
@@ -441,7 +446,13 @@ RCT_EXPORT_METHOD(paymentRequestWithApplePay:(NSArray *)items
     if ([self canSubmitPaymentRequest:paymentRequest rejecter:reject]) {
         PKPaymentAuthorizationViewController *paymentAuthorizationVC = [[PKPaymentAuthorizationViewController alloc] initWithPaymentRequest:paymentRequest];
         paymentAuthorizationVC.delegate = self;
-        [RCTPresentedViewController() presentViewController:paymentAuthorizationVC animated:YES completion:nil];
+        
+        // move to the end of main queue
+        // allow the execution of hiding modal
+        // to be finished first
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [RCTPresentedViewController() presentViewController:paymentAuthorizationVC animated:YES completion:nil];
+        });
     } else {
         // There is a problem with your Apple Pay configuration.
         [self resetPromiseCallbacks];


### PR DESCRIPTION
Fix:STPAddCardViewController disappear immediately after is being presented.
Reason: `paymentRequestWithCardForm` is called in side another modalViewController's callback.
That block of callback is onModalHide which is Reactnative's built-in function.
There is a conflict that when onModalHide is called, we call paymentRequestWithCardForm which is presenting the STPAddCardViewController 
But, at the moment, the current Modal which is own onModalHide is still alive because of its memory is still being use by the onModalHide's block's content.
After paymentRequestWithCardForm is called, it mean we call `[RCTPresentedViewController() presentViewController:navigationController animated:YES completion:nil];` , then onModalHide() will return.
Then react-native framework will continue it job which is release the modalViewController, but not, the top presented is STPAddCardViewController.
So, I allow the onModalHide finish first by moving `[RCTPresentedViewController() presentViewController:navigationController animated:YES completion:nil];` to the end of main_queue.

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes
What types of changes does your code introduce to `tipsi-stripe`?  
_Put an `x` in the boxes that apply_

- [x] Bugfix (a non-breaking change which fixes an issue)  
- [ ] New feature (a non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! Next steps are a reminder of what we are going to look at before merging your code._

- [x] I have added tests that prove my fix is useful or that my feature works  
- [x] I have added necessary documentation (if appropriate)  
- [x] I know that my PR will be merged only if it has tests and they pass  

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you choose the solution you did and what alternatives you considered.
