### PR TITLE
Remove broken imports for ViewStylePropTypes

### DIFF
--- a/src/components/PaymentCardTextField.js
+++ b/src/components/PaymentCardTextField.js
@@ -9,12 +9,10 @@ import {
   Platform,
 } from 'react-native'
 import PropTypes from 'prop-types'
-import StyleSheetPropType from 'react-native/Libraries/StyleSheet/StyleSheetPropType'
-import ViewStylePropTypes from 'react-native/Libraries/Components/View/ViewStylePropTypes'
 import TextInputState from 'react-native/Libraries/Components/TextInput/TextInputState'
 
 const FieldStylePropType = {
-  ...ViewStylePropTypes,
+  ...ViewPropTypes.style,
   color: PropTypes.string,
 }
 
@@ -38,7 +36,7 @@ const NativePaymentCardTextField = requireNativeComponent('TPSCardField', Paymen
 export default class PaymentCardTextField extends Component {
   static propTypes = {
     ...ViewPropTypes,
-    style: StyleSheetPropType(FieldStylePropType), // eslint-disable-line new-cap
+    style: FieldStylePropType,
 
     // Common
     expirationPlaceholder: PropTypes.string,


### PR DESCRIPTION
## Proposed changes
With this [PR](https://github.com/facebook/react-native/pull/21380/files) the files `react-native/Libraries/Components/View/ViewStylePropTypes` and `react-native/Libraries/StyleSheet/StyleSheetPropType` no longer exist. Due to this following imports are broken.
https://github.com/tipsi/tipsi-stripe/blob/339cea10bc7c45b341154c37d3ef4d96db6cc906/src/components/PaymentCardTextField.js#L13
This changes fixes tipsi-stripe for react-native 0.58 and above.

## Types of changes
What types of changes does your code introduce to `tipsi-stripe`?  
_Put an `x` in the boxes that apply_

- [x] Bugfix (a non-breaking change which fixes an issue)  
- [ ] New feature (a non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! Next steps are a reminder of what we are going to look at before merging your code._

- [ ] I have added tests that prove my fix is useful or that my feature works  
- [ ] I have added necessary documentation (if appropriate)  
- [ ] I know that my PR will be merged only if it has tests and they pass  

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you choose the solution you did and what alternatives you considered.
