### PR TITLE
call reject directly in createSourceWithParams

### DIFF
--- a/ios/TPSStripe/TPSStripeManager.m
+++ b/ios/TPSStripe/TPSStripeManager.m
@@ -290,7 +290,7 @@ RCT_EXPORT_METHOD(createSourceWithParams:(NSDictionary *)params
 
         if (error) {
             NSDictionary *jsError = [errorCodes valueForKey:kErrorKeyApi];
-            [self rejectPromiseWithCode:jsError[kErrorKeyCode] message:error.localizedDescription];
+            reject(jsError[kErrorKeyCode], error.localizedDescription, nil);
         } else {
             if (source.redirect) {
                 self.redirectContext = [[STPRedirectContext alloc] initWithSource:source completion:^(NSString *sourceID, NSString *clientSecret, NSError *error) {


### PR DESCRIPTION


## Proposed changes
The instance vars `promiseResolver` and `promiseRejector` are not set in `createSourceWithParams`. My assumption is because the promise handlers are not needed in a separate method. As written if there is an error creating the promise `rejectPromiseWithCode` is called which is a no op since `promiseRejector` is nil. This PR simply calls `reject` directly in this instance as it is called for every other error in this method. This should fix [this](https://github.com/tipsi/tipsi-stripe/issues/291) issue.

## Types of changes
What types of changes does your code introduce to `tipsi-stripe`?  
_Put an `x` in the boxes that apply_

- [ x ] Bugfix (a non-breaking change which fixes an issue)  
- [ ] New feature (a non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! Next steps are a reminder of what we are going to look at before merging your code._

- [ ] I have added tests that prove my fix is useful or that my feature works  
- [ ] I have added necessary documentation (if appropriate)  
- [ ] I know that my PR will be merged only if it has tests and they pass  

