### PR TITLE
added setParams for android credit card form

### DIFF
--- a/android/src/main/java/com/gettipsi/stripe/CustomCardInputReactManager.java
+++ b/android/src/main/java/com/gettipsi/stripe/CustomCardInputReactManager.java
@@ -11,6 +11,7 @@ import android.view.inputmethod.InputMethodManager;
 import com.devmarvel.creditcardentry.library.CreditCardForm;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
@@ -108,6 +109,19 @@ public class CustomCardInputReactManager extends SimpleViewManager<CreditCardFor
   @ReactProp(name = "cvcPlaceholder")
   public void setSecurityCodeTextHint(CreditCardForm view, String securityCodeTextHint) {
     view.setSecurityCodeTextHint(securityCodeTextHint);
+  }
+
+  @ReactProp(name = "params")
+  public void setParams(CreditCardForm view, ReadableMap card) {
+    this.setCardNumber(view, card.getString("number"));
+    long month = Math.round(card.getDouble("expMonth"));
+    long year = Math.round(card.getDouble("expYear"));
+    if (month == 0 && year == 0){
+      this.setExpDate(view, "");
+    } else {
+      this.setExpDate(view, String.valueOf(month) + "/" + String.valueOf(month));
+    }
+    this.setSecurityCode(view, card.getString("cvc"));
   }
 
 


### PR DESCRIPTION
You can only pass in a double for the expiration month and year so if each is set to zero, then the field clears.
