### PR TITLE
Fix typo: sourceStatusCanceled -> sourceStatusCancelled

### DIFF
--- a/docs/docs/errorcodes.html
+++ b/docs/docs/errorcodes.html
@@ -13,7 +13,7 @@
 <tr><td style="text-align:left"><strong>busy</strong></td><td style="text-align:left">Previous request is not completed</td></tr>
 <tr><td style="text-align:left"><strong>cancelled</strong></td><td style="text-align:left">Cancelled by user</td></tr>
 <tr><td style="text-align:left"><strong>purchaseCancelled</strong></td><td style="text-align:left">Purchase was cancelled</td></tr>
-<tr><td style="text-align:left"><strong>sourceStatusCanceled</strong></td><td style="text-align:left">Cancelled by user</td></tr>
+<tr><td style="text-align:left"><strong>sourceStatusCancelled</strong></td><td style="text-align:left">Cancelled by user</td></tr>
 <tr><td style="text-align:left"><strong>sourceStatusPending</strong></td><td style="text-align:left">The source has been created and is awaiting customer action</td></tr>
 <tr><td style="text-align:left"><strong>sourceStatusFailed</strong></td><td style="text-align:left">The source status is unknown. You shouldn't encounter this value.</td></tr>
 <tr><td style="text-align:left"><strong>sourceStatusUnknown</strong></td><td style="text-align:left">Source polling unknown error</td></tr>

--- a/ios/TPSStripe/TPSStripeManager.m
+++ b/ios/TPSStripe/TPSStripeManager.m
@@ -18,7 +18,7 @@ NSString * const kErrorKeyBusy = @"busy";
 NSString * const kErrorKeyApi = @"api";
 NSString * const kErrorKeyRedirectSpecific = @"redirectSpecific";
 NSString * const kErrorKeyCancelled = @"cancelled";
-NSString * const kErrorKeySourceStatusCanceled = @"sourceStatusCanceled";
+NSString * const kErrorKeysourceStatusCancelled = @"sourceStatusCancelled";
 NSString * const kErrorKeySourceStatusPending = @"sourceStatusPending";
 NSString * const kErrorKeySourceStatusFailed = @"sourceStatusFailed";
 NSString * const kErrorKeySourceStatusUnknown = @"sourceStatusUnknown";
@@ -308,8 +308,8 @@ RCT_EXPORT_METHOD(createSourceWithParams:(NSDictionary *)params
                                     case STPSourceStatusConsumed:
                                         resolve([self convertSourceObject:source]);
                                         break;
-                                    case STPSourceStatusCanceled: {
-                                        NSDictionary *error = [errorCodes valueForKey:kErrorKeySourceStatusCanceled];
+                                    case STPsourceStatusCancelled: {
+                                        NSDictionary *error = [errorCodes valueForKey:kErrorKeysourceStatusCancelled];
                                         reject(error[kErrorKeyCode], error[kErrorKeyDescription], nil);
                                     }
                                         break;
@@ -901,7 +901,7 @@ RCT_EXPORT_METHOD(openApplePaySetup) {
             return @"chargable";
         case STPSourceStatusConsumed:
             return @"consumed";
-        case STPSourceStatusCanceled:
+        case STPsourceStatusCancelled:
             return @"canceled";
         case STPSourceStatusFailed:
             return @"failed";

--- a/src/errorCodes.js
+++ b/src/errorCodes.js
@@ -13,8 +13,8 @@ const errorCodes = {
     errorCode: 'purchaseCancelled',
     description: 'Purchase was cancelled',
   },
-  sourceStatusCanceled: {
-    errorCode: 'sourceStatusCanceled',
+  sourceStatusCancelled: {
+    errorCode: 'sourceStatusCancelled',
     description: 'Cancelled by user',
   },
   sourceStatusPending: {

--- a/website/docs-md/errorcodes.md
+++ b/website/docs-md/errorcodes.md
@@ -11,7 +11,7 @@ sidebar_label: Error Codes
 | **busy** | Previous request is not completed |
 | **cancelled** | Cancelled by user |
 | **purchaseCancelled** | Purchase was cancelled |
-| **sourceStatusCanceled** | Cancelled by user |
+| **sourceStatusCancelled** | Cancelled by user |
 | **sourceStatusPending** | The source has been created and is awaiting customer action |
 | **sourceStatusFailed** | The source status is unknown. You shouldn\'t encounter this value. |
 | **sourceStatusUnknown** | Source polling unknown error |


### PR DESCRIPTION
## Proposed changes 
> Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to link to that issue.

This is a bug fix will cause breaking change
I found the error code should be `sourceStatusCancelled` instead of `sourceStatusCanceled`. `sourceStatusCanceled` should be also correct, but the other codes are using `Cancelled`, I suppose they should be consistent. 
This is change will cause `sourceStatusCanceled` not be handled, so I'm not sure how to fix it would be better. I only fixed the typo that I could find in codes for now.

## Types of changes
What types of changes does your code introduce to `tipsi-stripe`?  
_Put an `x` in the boxes that apply_

- [ ] Bug fix (a non-breaking change which fixes an issue)  
- [ ] New feature (a non-breaking change which adds functionality)  
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! Next steps are a reminder of what we are going to look at before merging your code._

- [ ] I have added tests that prove my fix is useful or that my feature works  
- [ ] I have added necessary documentation (if appropriate)  
- [x] I know that my PR will be merged only if it has tests and they pass  

## Further comments
> If this is a relatively large or complex change, kick off the discussion by explaining why you choose the solution you did and what alternatives you considered.