### PR TITLE
Google pay - capture email

### DIFF
--- a/android/src/main/java/com/gettipsi/stripe/GoogleApiPayFlowImpl.java
+++ b/android/src/main/java/com/gettipsi/stripe/GoogleApiPayFlowImpl.java
@@ -39,6 +39,7 @@ import static com.gettipsi.stripe.util.PayParams.CURRENCY_CODE;
 import static com.gettipsi.stripe.util.PayParams.BILLING_ADDRESS_REQUIRED;
 import static com.gettipsi.stripe.util.PayParams.SHIPPING_ADDRESS_REQUIRED;
 import static com.gettipsi.stripe.util.PayParams.PHONE_NUMBER_REQUIRED;
+import static com.gettipsi.stripe.util.PayParams.EMAIL_REQUIRED;
 import static com.gettipsi.stripe.util.PayParams.TOTAL_PRICE;
 
 /**
@@ -103,6 +104,7 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
     final boolean billingAddressRequired = Converters.getValue(payParams, BILLING_ADDRESS_REQUIRED, false);
     final boolean shippingAddressRequired = Converters.getValue(payParams, SHIPPING_ADDRESS_REQUIRED, false);
     final boolean phoneNumberRequired = Converters.getValue(payParams, PHONE_NUMBER_REQUIRED, false);
+    final boolean emailRequired = Converters.getValue(payParams, EMAIL_REQUIRED, false);
     final Collection<String> allowedCountryCodes = getAllowedShippingCountryCodes(payParams);
 
     return createPaymentDataRequest(
@@ -120,6 +122,7 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
                                                       final boolean billingAddressRequired,
                                                       final boolean shippingAddressRequired,
                                                       final boolean phoneNumberRequired,
+                                                      final boolean emailRequired,
                                                       @NonNull final Collection<String> countryCodes
   ) {
 
@@ -147,6 +150,7 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
           .build())
       .addAllowedPaymentMethod(WalletConstants.PAYMENT_METHOD_CARD)
       .addAllowedPaymentMethod(WalletConstants.PAYMENT_METHOD_TOKENIZED_CARD)
+      .setEmailRequired(emailRequired)
       .setShippingAddressRequired(shippingAddressRequired)
       .setPhoneNumberRequired(phoneNumberRequired);
 
@@ -235,7 +239,8 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
               payPromise.resolve(putExtraToTokenMap(
                 convertTokenToWritableMap(token),
                 getBillingAddress(paymentData),
-                paymentData.getShippingAddress()));
+                paymentData.getShippingAddress(),
+                paymentData.getEmail()));
             }
             break;
           case Activity.RESULT_CANCELED:

--- a/android/src/main/java/com/gettipsi/stripe/GoogleApiPayFlowImpl.java
+++ b/android/src/main/java/com/gettipsi/stripe/GoogleApiPayFlowImpl.java
@@ -113,6 +113,7 @@ public final class GoogleApiPayFlowImpl extends PayFlow {
       billingAddressRequired,
       shippingAddressRequired,
       phoneNumberRequired,
+      emailRequired,
       allowedCountryCodes
     );
   }

--- a/android/src/main/java/com/gettipsi/stripe/util/Converters.java
+++ b/android/src/main/java/com/gettipsi/stripe/util/Converters.java
@@ -53,13 +53,22 @@ public class Converters {
     return newToken;
   }
 
-  public static WritableMap putExtraToTokenMap(final WritableMap tokenMap, UserAddress billingAddress, UserAddress shippingAddress) {
+  public static WritableMap putExtraToTokenMap(final WritableMap tokenMap, UserAddress billingAddress, UserAddress shippingAddress, String emailAddress) {
     ArgCheck.nonNull(tokenMap);
 
     WritableMap extra = Arguments.createMap();
 
-    extra.putMap("billingContact", convertAddressToWritableMap(billingAddress));
-    extra.putMap("shippingContact", convertAddressToWritableMap(shippingAddress));
+    //add email address to billing and shipping contact as per apple
+    WritableMap billingContactMap = convertAddressToWritableMap(billingAddress);
+    WritableMap shippingContactMap = convertAddressToWritableMap(shippingAddress);
+
+    billingContactMap.putString("emailAddress", emailAddress);
+    shippingContactMap.putString("emailAddress", emailAddress);
+    
+
+    extra.putMap("billingContact", billingContactMap);
+    extra.putMap("shippingContact", shippingContactMap);
+    
     tokenMap.putMap("extra", extra);
 
     return tokenMap;

--- a/android/src/main/java/com/gettipsi/stripe/util/PayParams.java
+++ b/android/src/main/java/com/gettipsi/stripe/util/PayParams.java
@@ -10,6 +10,7 @@ public abstract class PayParams {
   public static final String BILLING_ADDRESS_REQUIRED = "billing_address_required";
   public static final String SHIPPING_ADDRESS_REQUIRED = "shipping_address_required";
   public static final String PHONE_NUMBER_REQUIRED = "phone_number_required";
+  public static final String EMAIL_REQUIRED = "email_required";
   public static final String TOTAL_PRICE = "total_price";
   public static final String UNIT_PRICE = "unit_price";
   public static final String LINE_ITEMS = "line_items";

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -135,6 +135,7 @@ export const paymentRequestWithAndroidPayOptionsPropTypes = {
   line_items: PropTypes.arrayOf(PropTypes.shape(androidPayLineItemPropTypes)).isRequired,
   shipping_address_required: PropTypes.bool,
   billing_address_required: PropTypes.bool,
+  email_address_required: PropTypes.bool,
 }
 
 export const createSourceWithParamsPropType = {


### PR DESCRIPTION
## Proposed changes
You can now supply email_required true to paymentRequestWithAndroidPay and email address will be added to extra.shippingAddress and extra.billingAddress in line with Apple pay.


Replaces: https://github.com/tipsi/tipsi-stripe/pull/279 which was out of date

## Types of changes
What types of changes does your code introduce to `tipsi-stripe`?  
_Put an `x` in the boxes that apply_

- [ ] Bugfix (a non-breaking change which fixes an issue)  
- [x] New feature (a non-breaking change which adds functionality)  
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! Next steps are a reminder of what we are going to look at before merging your code._

- [ ] I have added tests that prove my fix is useful or that my feature works  
- [ ] I have added necessary documentation (if appropriate)  
- [ ] I know that my PR will be merged only if it has tests and they pass  

N/A to all - there's no tests that I know of and the docs are duplicated in three different places. I don't know which ones I am updating. Are they auto-generated somehow? Happy to add if I can be pointed to where.

## Further comments
Simple change. Have introduced the option to request email or not which defaults to false and placed email in the shipping and billing fields instead of on its own to bring in line with IOS.
