### PR TITLE
Change googlePlayServicesVersion and firebaseVersion default values.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'com.android.library'
 def DEFAULT_COMPILE_SDK_VERSION             = 26
 def DEFAULT_TARGET_SDK_VERSION              = 26
 def DEFAULT_BUILD_TOOLS_VERSION             = '26.0.2'
-def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION    = '11.8.0'
-def DEFAULT_FIREBASE_MESSAGING_VERSION      = '11.8.0'
+def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION    = '+'
+def DEFAULT_FIREBASE_MESSAGING_VERSION      = '+'
 
 android {
   compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'com.android.library'
 def DEFAULT_COMPILE_SDK_VERSION             = 26
 def DEFAULT_TARGET_SDK_VERSION              = 26
 def DEFAULT_BUILD_TOOLS_VERSION             = '26.0.2'
-def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION    = '+'
-def DEFAULT_FIREBASE_MESSAGING_VERSION      = '+'
+def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION    = '16.0.1'
+def DEFAULT_FIREBASE_MESSAGING_VERSION      = '16.0.9'
 
 android {
   compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION


### PR DESCRIPTION
## Proposed changes
Changing `googlePlayServicesVersion` or `firebaseVersion` through project property sometimes causes conflict with other libraries for example react-native-device-info. So I propose to set the default values as the newest version before AndroidX became necessary.

## Types of changes
What types of changes does your code introduce to `tipsi-stripe`?  
_Put an `x` in the boxes that apply_

- [x] Bugfix (a non-breaking change which fixes an issue)  
- [ ] New feature (a non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! Next steps are a reminder of what we are going to look at before merging your code._

- [ ] I have added tests that prove my fix is useful or that my feature works  
- [ ] I have added necessary documentation (if appropriate)  
- [ ] I know that my PR will be merged only if it has tests and they pass  

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you choose the solution you did and what alternatives you considered.
