### PR TITLE
Fix field focus infinite recursion in keyboardWillShow on > RN 45

### DIFF
--- a/ios/TPSStripe.xcodeproj/project.pbxproj
+++ b/ios/TPSStripe.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 				3A228EB01DC52E54007BB9D0 /* Frameworks */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		3A3A7F1B1DC27B520030F9DC /* Products */ = {
 			isa = PBXGroup;

--- a/ios/TPSStripe/TPSCardField.m
+++ b/ios/TPSStripe/TPSCardField.m
@@ -12,10 +12,11 @@
 @end
 
 @implementation TPSCardField {
+    // Relates to a Deprecated API -- clean this up after RN 0.45 or lower support is dropped
     BOOL _jsRequestingFirstResponder;
     BOOL _isFirstResponder;
-    STPPaymentCardTextField *_paymentCardTextField;
 
+    STPPaymentCardTextField *_paymentCardTextField;
 }
 
 - (void)dealloc {
@@ -30,10 +31,10 @@
         [self addSubview:_paymentCardTextField];
         self.backgroundColor = [UIColor clearColor];
         [[NSNotificationCenter defaultCenter]
-            addObserver:self
-               selector:@selector(keyboardWillShow:)
-                   name:UIKeyboardWillShowNotification
-                 object:self.window];
+         addObserver:self
+         selector:@selector(keyboardWillShow:)
+         name:UIKeyboardWillShowNotification
+         object:self.window];
     }
     return self;
 }
@@ -43,6 +44,23 @@
     _paymentCardTextField.frame = self.bounds;
 }
 
+- (void)reactFocus {
+    _jsRequestingFirstResponder = YES;
+    [self becomeFirstResponder];
+}
+
+- (void)reactFocusIfNeeded {
+    if (!_isFirstResponder) {
+        [self reactFocus];
+    }
+}
+
+- (void)reactBlur {
+    _jsRequestingFirstResponder = NO;
+    [self resignFirstResponder];
+}
+
+// Deprecated API -- removed in 2017, clean this up after RN 0.45 or lower support is dropped
 - (void)reactWillMakeFirstResponder {
     _jsRequestingFirstResponder = YES;
 }
@@ -51,6 +69,7 @@
     return _jsRequestingFirstResponder;
 }
 
+// Deprecated API -- removed in 2017, clean this up after RN 0.45 or lower support is dropped
 - (void)reactDidMakeFirstResponder {
     _jsRequestingFirstResponder = NO;
 }
@@ -74,6 +93,7 @@
 }
 
 - (BOOL)resignFirstResponder {
+    _jsRequestingFirstResponder = NO;
     _isFirstResponder = NO;
     return [_paymentCardTextField resignFirstResponder];
 }
@@ -179,11 +199,11 @@
 }
 
 - (UIKeyboardAppearance)keyboardAppearance {
-  return _paymentCardTextField.keyboardAppearance;
+    return _paymentCardTextField.keyboardAppearance;
 }
 
 - (void)setKeyboardAppearance:(UIKeyboardAppearance)keyboardAppearance {
-  _paymentCardTextField.keyboardAppearance = keyboardAppearance;
+    _paymentCardTextField.keyboardAppearance = keyboardAppearance;
 }
 
 #pragma mark - STPPaymentCardTextFieldDelegate


### PR DESCRIPTION
## Proposed changes

Fixes https://github.com/tipsi/tipsi-stripe/issues/408

React-Native removed support for the react(Will|Did)MakeFirstResponder APIs in this commit: https://github.com/facebook/react-native/commit/bc1ea548d0017f131c36a30ce06bf4d512cb2f8c#diff-3e154f92c7ba4cb47e96785b9dadf3aa

This PR implements the "new" methods that react-native added in 2017 to replace these deprecated APIs. It does so in a hopefully backwards compatible way, but if we can drop support for < 0.45, then I'd be thrilled to clean the implementation up, further.

## Types of changes

- [x] Bugfix (a non-breaking change which fixes an issue)  
- [ ] New feature (a non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

## Checklist
<!--_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! Next steps are a reminder of what we are going to look at before merging your code._-->

I'd be thrilled to add tests, if somebody can show me where / how. I would have assumed existing tests should cover this case!

- [ ] I have added tests that prove my fix is useful or that my feature works  
- [ ] I have added necessary documentation (if appropriate)  
- [ ] I know that my PR will be merged only if it has tests and they pass  

## Further comments

If we can drop support for < 0.45, then I'd be thrilled to clean the implementation up, further.

/cc @mindlapse