### PR TITLE
iOS support for tokens

### DIFF
--- a/ios/TPSStripe/TPSStripeManager+Constants.m
+++ b/ios/TPSStripe/TPSStripeManager+Constants.m
@@ -56,6 +56,7 @@ TPSStripeBridgeKeyDeclare(CardParams, addressCity);
 TPSStripeBridgeKeyDeclare(CardParams, addressState);
 TPSStripeBridgeKeyDeclare(CardParams, addressCountry);
 TPSStripeBridgeKeyDeclare(CardParams, addressZip);
+TPSStripeBridgeKeyDeclare(CardParams, token);
 
 TPSStripeBridgeTypeDefine(confirmPayment);
 TPSStripeBridgeKeyDeclare(confirmPayment, clientSecret);

--- a/ios/TPSStripe/TPSStripeManager.m
+++ b/ios/TPSStripe/TPSStripeManager.m
@@ -890,13 +890,11 @@ RCT_EXPORT_METHOD(openApplePaySetup) {
     }
 
     STPPaymentMethodCardParams * card = nil;
-    if ([params isKindOfClass:NSString.class]) {
-        card = [[STPPaymentMethodCardParams alloc] init];
-        card.token = (NSString*)params;
-    } else if ([params isKindOfClass:NSDictionary.class]) {
+    if ([params isKindOfClass:NSDictionary.class]) {
         card = [[STPPaymentMethodCardParams alloc] initWithCardSourceParams:[self extractCardParamsFromDictionary:params]];
+        card.token = [RCTConvert NSString:params[TPSStripeParam(CardParams, token)]]
     } else {
-        NSParameterAssert([params isKindOfClass:NSString.class] || [params isKindOfClass:NSDictionary.class]);
+        NSParameterAssert([params isKindOfClass:NSDictionary.class]);
         return nil;
     }
     return card;


### PR DESCRIPTION
The propType defines that a token would be present as part of a Map under the key 'token', instead of as a String