### PR TITLE
Android card brand consistency

### DIFF
--- a/android/src/main/java/com/gettipsi/stripe/util/Converters.java
+++ b/android/src/main/java/com/gettipsi/stripe/util/Converters.java
@@ -69,11 +69,11 @@ public class Converters {
 
     billingContactMap.putString("emailAddress", emailAddress);
     shippingContactMap.putString("emailAddress", emailAddress);
-    
+
 
     extra.putMap("billingContact", billingContactMap);
     extra.putMap("shippingContact", shippingContactMap);
-    
+
     tokenMap.putMap("extra", extra);
 
     return tokenMap;
@@ -97,7 +97,7 @@ public class Converters {
     result.putString("addressZip", card.getAddressZip() );
     result.putString("addressCountry", card.getAddressCountry() );
     result.putString("last4", card.getLast4() );
-    result.putString("brand", card.getBrand() );
+    result.putString("brand", Converters.convertCardBrandToString(card.getBrand()) );
     result.putString("funding", card.getFunding() );
     result.putString("fingerprint", card.getFingerprint() );
     result.putString("country", card.getCountry() );
@@ -284,6 +284,23 @@ public class Converters {
   }
 
   @NonNull
+  public static String convertCardBrandToString(@Nullable final PaymentMethod.Card.CardBrand brand) {
+    // Documentation: https://stripe.com/docs/api/cards/object#card_object-brand
+    switch(brand) {
+      case Card.CardBrand.AMERICAN_EXPRESS: return "American Express";
+      case Card.CardBrand.DINERS_CLUB: return "Diners Club";
+      case Card.CardBrand.DISCOVER: return "Discover";
+      case Card.CardBrand.JCB: return "JCB";
+      case Card.CardBrand.MASTERCARD: return "MasterCard";
+      case Card.CardBrand.UNIONPAY: return "UnionPay";
+      case Card.CardBrand.VISA: return "Visa";
+      case Card.CardBrand.UNKNOWN:
+      default:
+        return "Unknown";
+    }
+  }
+
+  @NonNull
   public static WritableMap convertPaymentMethodCardToWritableMap(@Nullable final PaymentMethod.Card card) {
     WritableMap wm = Arguments.createMap();
 
@@ -293,7 +310,7 @@ public class Converters {
 
     // Omitted (can be introduced later): card.checks, card.threeDSecureUsage, card.wallet
 
-    wm.putString("brand", card.brand);
+    wm.putString("brand", Converters.convertCardBrandToString(card.brand));
     wm.putString("country", card.country);
     wm.putInt("expMonth", card.expiryMonth);
     wm.putInt("expYear", card.expiryYear);


### PR DESCRIPTION
In the Discord chat, @e-nouri commented that he noticed that the Card Brands had an inconsistency between iOS & Android.

While investigating, I found the official docs that say the brands are a "human friendly string". [Documentation](https://stripe.com/docs/api/cards/object#card_object-brand)

When looking at the iOS code that existed, it was already converting the enum to a presentable string, but it was avoiding using the official utility to do that. (Fixed in commit: [248c3a2](https://github.com/tipsi/tipsi-stripe/commit/248c3a238fb207c894b4c5bad498481815410e92))

Looking at Android, I couldn't find an official utility to convert the strings for consistency, so I made an attempt at writing my own in this PR.