### PR TITLE
Payment Method id for confirm (Setup) Intent Results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Target SDK Version increased from 26 -> 28
 - Min SDK Version increased from 16 -> 19
 - Support libraries increased from 27.1.0 to 28.0.0
-- `stripe-android` upgraded from 8.1.0 to 10.2.1
+- `stripe-android` upgraded from 8.1.0 to 10.4.0
 
 ### iOS
 

--- a/android/src/main/java/com/gettipsi/stripe/util/Converters.java
+++ b/android/src/main/java/com/gettipsi/stripe/util/Converters.java
@@ -247,12 +247,10 @@ public class Converters {
     wm.putString("status", intent.getStatus().toString());
     wm.putString("paymentIntentId", intent.getId());
 
-    // The current generation of stripe-android does not expose getPaymentMethodId on PaymentIntents :(
-    // Feature Request: https://github.com/stripe/stripe-android/issues/1445
-    // String paymentMethodId = intent.getPaymentMethodId();
-    // if (paymentMethodId != null) {
-    //   wm.putString("paymentMethodId", paymentMethodId);
-    // }
+    String paymentMethodId = intent.getPaymentMethodId();
+    if (paymentMethodId != null) {
+      wm.putString("paymentMethodId", paymentMethodId);
+    }
     return wm;
   }
 

--- a/android/src/main/java/com/gettipsi/stripe/util/Converters.java
+++ b/android/src/main/java/com/gettipsi/stripe/util/Converters.java
@@ -242,8 +242,16 @@ public class Converters {
       return wm;
     }
 
-    wm.putString("status", paymentIntentResult.getIntent().getStatus().toString());
-    wm.putString("paymentIntentId", paymentIntentResult.getIntent().getId());
+    PaymentIntent intent = paymentIntentResult.getIntent();
+    wm.putString("status", intent.getStatus().toString());
+    wm.putString("paymentIntentId", intent.getId());
+
+    // The current generation of stripe-android does not expose getPaymentMethodId on PaymentIntents :(
+    // Feature Request: https://github.com/stripe/stripe-android/issues/1445
+    // String paymentMethodId = intent.getPaymentMethodId();
+    // if (paymentMethodId != null) {
+    //   wm.putString("paymentMethodId", paymentMethodId);
+    // }
     return wm;
   }
 
@@ -256,8 +264,14 @@ public class Converters {
       return wm;
     }
 
-    wm.putString("status", setupIntentResult.getIntent().getStatus().toString());
-    wm.putString("setupIntentId", setupIntentResult.getIntent().getId());
+    SetupIntent intent = setupIntentResult.getIntent();
+    wm.putString("status", intent.getStatus().toString());
+    wm.putString("setupIntentId", intent.getId());
+
+    String paymentMethodId = intent.getPaymentMethodId();
+    if (paymentMethodId != null) {
+      wm.putString("paymentMethodId", paymentMethodId);
+    }
     return wm;
   }
 

--- a/ios/TPSStripe/TPSStripeManager+Constants.h
+++ b/ios/TPSStripe/TPSStripeManager+Constants.h
@@ -70,6 +70,7 @@ TPSStripeBridgeKeyDeclare(confirmPaymentIntent, savePaymentMethod);
 
 TPSStripeBridgeTypeDefine(ConfirmPaymentIntentResult);
 TPSStripeBridgeKeyDeclare(ConfirmPaymentIntentResult, paymentIntentId);
+TPSStripeBridgeKeyDeclare(ConfirmPaymentIntentResult, paymentMethodId);
 TPSStripeBridgeKeyDeclare(ConfirmPaymentIntentResult, status);
 
 TPSStripeBridgeTypeDefine(authenticatePaymentIntent);
@@ -77,6 +78,7 @@ TPSStripeBridgeKeyDeclare(authenticatePaymentIntent, clientSecret);
 
 TPSStripeBridgeTypeDefine(AuthenticatePaymentIntentResult);
 TPSStripeBridgeKeyDeclare(AuthenticatePaymentIntentResult, paymentIntentId);
+TPSStripeBridgeKeyDeclare(AuthenticatePaymentIntentResult, paymentMethodId);
 TPSStripeBridgeKeyDeclare(AuthenticatePaymentIntentResult, status);
 
 TPSStripeBridgeTypeDefine(confirmSetupIntent);
@@ -89,6 +91,7 @@ TPSStripeBridgeKeyDeclare(confirmSetupIntent, savePaymentMethod);
 
 TPSStripeBridgeTypeDefine(ConfirmSetupIntentResult);
 TPSStripeBridgeKeyDeclare(ConfirmSetupIntentResult, setupIntentId);
+TPSStripeBridgeKeyDeclare(ConfirmSetupIntentResult, paymentMethodId);
 TPSStripeBridgeKeyDeclare(ConfirmSetupIntentResult, status);
 
 TPSStripeBridgeTypeDefine(authenticateSetupIntent);
@@ -96,6 +99,7 @@ TPSStripeBridgeKeyDeclare(authenticateSetupIntent, clientSecret);
 
 TPSStripeBridgeTypeDefine(AuthenticateSetupIntentResult);
 TPSStripeBridgeKeyDeclare(AuthenticateSetupIntentResult, setupIntentId);
+TPSStripeBridgeKeyDeclare(AuthenticateSetupIntentResult, paymentMethodId);
 TPSStripeBridgeKeyDeclare(AuthenticateSetupIntentResult, status);
 
 TPSStripeBridgeTypeDefine(PaymentIntentStatus);

--- a/ios/TPSStripe/TPSStripeManager+Constants.m
+++ b/ios/TPSStripe/TPSStripeManager+Constants.m
@@ -69,6 +69,7 @@ TPSStripeBridgeKeyDeclare(confirmPaymentIntent, savePaymentMethod);
 
 TPSStripeBridgeTypeDefine(ConfirmPaymentIntentResult);
 TPSStripeBridgeKeyDeclare(ConfirmPaymentIntentResult, paymentIntentId);
+TPSStripeBridgeKeyDeclare(ConfirmPaymentIntentResult, paymentMethodId);
 TPSStripeBridgeKeyDeclare(ConfirmPaymentIntentResult, status);
 
 TPSStripeBridgeTypeDefine(authenticatePaymentIntent);
@@ -76,6 +77,7 @@ TPSStripeBridgeKeyDeclare(authenticatePaymentIntent, clientSecret);
 
 TPSStripeBridgeTypeDefine(AuthenticatePaymentIntentResult);
 TPSStripeBridgeKeyDeclare(AuthenticatePaymentIntentResult, paymentIntentId);
+TPSStripeBridgeKeyDeclare(AuthenticatePaymentIntentResult, paymentMethodId);
 TPSStripeBridgeKeyDeclare(AuthenticatePaymentIntentResult, status);
 
 TPSStripeBridgeTypeDefine(confirmSetupIntent);
@@ -88,6 +90,7 @@ TPSStripeBridgeKeyDeclare(confirmSetupIntent, savePaymentMethod);
 
 TPSStripeBridgeTypeDefine(ConfirmSetupIntentResult);
 TPSStripeBridgeKeyDeclare(ConfirmSetupIntentResult, setupIntentId);
+TPSStripeBridgeKeyDeclare(ConfirmSetupIntentResult, paymentMethodId);
 TPSStripeBridgeKeyDeclare(ConfirmSetupIntentResult, status);
 
 TPSStripeBridgeTypeDefine(authenticateSetupIntent);
@@ -95,6 +98,7 @@ TPSStripeBridgeKeyDeclare(authenticateSetupIntent, clientSecret);
 
 TPSStripeBridgeTypeDefine(AuthenticateSetupIntentResult);
 TPSStripeBridgeKeyDeclare(AuthenticateSetupIntentResult, setupIntentId);
+TPSStripeBridgeKeyDeclare(AuthenticateSetupIntentResult, paymentMethodId);
 TPSStripeBridgeKeyDeclare(AuthenticateSetupIntentResult, status);
 
 TPSStripeBridgeTypeDefine(PaymentIntentStatus);

--- a/ios/TPSStripe/TPSStripeManager.m
+++ b/ios/TPSStripe/TPSStripeManager.m
@@ -995,20 +995,32 @@ RCT_EXPORT_METHOD(openApplePaySetup) {
         return @{ TPSStripeParam(ConfirmPaymentIntentResult, status): [RCTConvert STPPaymentIntentStatusString: STPPaymentIntentStatusUnknown] };
     }
 
-    return @{
-             TPSStripeParam(ConfirmPaymentIntentResult, paymentIntentId): intent.stripeId,
-             TPSStripeParam(ConfirmPaymentIntentResult, status): [RCTConvert STPPaymentIntentStatusString: intent.status],
-             };
+    NSMutableDictionary * result
+    = @{
+        TPSStripeParam(ConfirmPaymentIntentResult, paymentIntentId): intent.stripeId,
+        TPSStripeParam(ConfirmPaymentIntentResult, status): [RCTConvert STPPaymentIntentStatusString: intent.status],
+        }.mutableCopy;
+
+    // Optional parameters need to be serialized differently than non-nullable ones
+    [result setValue:intent.paymentMethodId forKey:TPSStripeParam(ConfirmPaymentIntentResult, paymentMethodId)];
+
+    return result;
 }
 - (NSDictionary<TPSStripeType(AuthenticatePaymentIntentResult), id>*)convertAuthenticatePaymentIntentResult:(STPPaymentIntent*)intent {
     if (!intent) {
         return @{ TPSStripeParam(AuthenticatePaymentIntentResult, status): [RCTConvert STPPaymentIntentStatusString: STPPaymentIntentStatusUnknown] };
     }
 
-    return @{
-             TPSStripeParam(AuthenticatePaymentIntentResult, paymentIntentId): intent.stripeId,
-             TPSStripeParam(AuthenticatePaymentIntentResult, status): [RCTConvert STPPaymentIntentStatusString: intent.status],
-             };
+    NSMutableDictionary * result
+    = @{
+        TPSStripeParam(AuthenticatePaymentIntentResult, paymentIntentId): intent.stripeId,
+        TPSStripeParam(AuthenticatePaymentIntentResult, status): [RCTConvert STPPaymentIntentStatusString: intent.status],
+        }.mutableCopy;
+
+    // Optional parameters need to be serialized differently than non-nullable ones
+    [result setValue:intent.paymentMethodId forKey:TPSStripeParam(AuthenticatePaymentIntentResult, paymentMethodId)];
+
+    return result;
 }
 
 - (NSDictionary<TPSStripeType(ConfirmSetupIntentResult), id>*)convertConfirmSetupIntentResult:(STPSetupIntent*)intent {
@@ -1016,20 +1028,32 @@ RCT_EXPORT_METHOD(openApplePaySetup) {
         return @{ TPSStripeParam(ConfirmSetupIntentResult, status): [RCTConvert STPSetupIntentStatusString: STPSetupIntentStatusUnknown] };
     }
 
-    return @{
-             TPSStripeParam(ConfirmSetupIntentResult, setupIntentId): intent.stripeID,
-             TPSStripeParam(ConfirmSetupIntentResult, status): [RCTConvert STPSetupIntentStatusString: intent.status],
-             };
+    NSMutableDictionary * result
+    = @{
+        TPSStripeParam(ConfirmSetupIntentResult, setupIntentId): intent.stripeID,
+        TPSStripeParam(ConfirmSetupIntentResult, status): [RCTConvert STPSetupIntentStatusString: intent.status],
+        }.mutableCopy;
+
+    // Optional parameters need to be serialized differently than non-nullable ones
+    [result setValue:intent.paymentMethodID forKey:TPSStripeParam(ConfirmSetupIntentResult, paymentMethodId)];
+
+    return result;
 }
 - (NSDictionary<TPSStripeType(AuthenticateSetupIntentResult), id>*)convertAuthenticateSetupIntentResult:(STPSetupIntent*)intent {
     if (!intent) {
         return @{ TPSStripeParam(AuthenticateSetupIntentResult, status): [RCTConvert STPSetupIntentStatusString: STPSetupIntentStatusUnknown] };
     }
 
-    return @{
-             TPSStripeParam(AuthenticateSetupIntentResult, setupIntentId): intent.stripeID,
-             TPSStripeParam(AuthenticateSetupIntentResult, status): [RCTConvert STPSetupIntentStatusString: intent.status],
-             };
+    NSMutableDictionary * result
+    = @{
+        TPSStripeParam(AuthenticateSetupIntentResult, setupIntentId): intent.stripeID,
+        TPSStripeParam(AuthenticateSetupIntentResult, status): [RCTConvert STPSetupIntentStatusString: intent.status],
+        }.mutableCopy;
+
+    // Optional parameters need to be serialized differently than non-nullable ones
+    [result setValue:intent.paymentMethodID forKey:TPSStripeParam(AuthenticateSetupIntentResult, paymentMethodId)];
+
+    return result;
 }
 
 - (NSDictionary*)convertPaymentMethod:(STPPaymentMethod*)method {

--- a/src/Stripe.js
+++ b/src/Stripe.js
@@ -96,7 +96,7 @@ import deprecatedMethodsForInstance from './Stripe.deprecated'
  * @typedef {Object} PaymentIntentConfirmationResult
  * @property {StripePaymentIntentStatus} status
  * @property {string} paymentIntentId
- * @property {string} paymentMethodId -- if available -- iOS-Only for now
+ * @property {string} paymentMethodId -- if available
  */
 
 /**
@@ -108,7 +108,7 @@ import deprecatedMethodsForInstance from './Stripe.deprecated'
  * @typedef {Object} PaymentIntentAuthenticationResult
  * @property {StripePaymentIntentStatus} status
  * @property {string} paymentIntentId
- * @property {string} paymentMethodId -- if available -- iOS-Only for now
+ * @property {string} paymentMethodId -- if available
  */
 
 /**

--- a/src/Stripe.js
+++ b/src/Stripe.js
@@ -96,6 +96,7 @@ import deprecatedMethodsForInstance from './Stripe.deprecated'
  * @typedef {Object} PaymentIntentConfirmationResult
  * @property {StripePaymentIntentStatus} status
  * @property {string} paymentIntentId
+ * @property {string} paymentMethodId -- if available -- iOS-Only for now
  */
 
 /**
@@ -107,6 +108,7 @@ import deprecatedMethodsForInstance from './Stripe.deprecated'
  * @typedef {Object} PaymentIntentAuthenticationResult
  * @property {StripePaymentIntentStatus} status
  * @property {string} paymentIntentId
+ * @property {string} paymentMethodId -- if available -- iOS-Only for now
  */
 
 /**
@@ -121,6 +123,7 @@ import deprecatedMethodsForInstance from './Stripe.deprecated'
  * @typedef {Object} SetupIntentConfirmationResult
  * @property {StripeSetupIntentStatus} status
  * @property {string} setupIntentId
+ * @property {string} paymentMethodId -- if available
  */
 
 /**
@@ -132,6 +135,7 @@ import deprecatedMethodsForInstance from './Stripe.deprecated'
  * @typedef {Object} SetupIntentAuthenticationResult
  * @property {StripeSetupIntentStatus} status
  * @property {string} setupIntentId
+ * @property {string} paymentMethodId -- if available
  */
 
 const { StripeModule } = NativeModules


### PR DESCRIPTION
## Proposed changes

My backend team really would like it if I submitted the paymentMethodId to the backend when using confirmSetupIntent/confirmPaymentIntent (when using the create payment method optional parameters) -- to do that I have to change the response object for those APIs.

## Types of changes

- [ ] Bugfix (a non-breaking change which fixes an issue)  
- [x] New feature (a non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

I discussed this in Discord, but people were offline at the time, so I figured I'd make a PR.

I wrote an attempt at the Android implementation, but I haven't verified if this fully works on Android. (This is our current convention).