### PR TITLE
Expose setStripeAccount to JS (Enable Stripe Connect accounts)

### DIFF
--- a/android/src/main/java/com/gettipsi/stripe/StripeModule.java
+++ b/android/src/main/java/com/gettipsi/stripe/StripeModule.java
@@ -145,7 +145,7 @@ public class StripeModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void setStripeAccount(final String stripeAccount) {
-    getPayFlow().setStripeAccount(stripeAccount);
+    mStripe.setStripeAccount(stripeAccount);
   }
 
   @ReactMethod

--- a/android/src/main/java/com/gettipsi/stripe/StripeModule.java
+++ b/android/src/main/java/com/gettipsi/stripe/StripeModule.java
@@ -144,6 +144,11 @@ public class StripeModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void setStripeAccount(final String stripeAccount) {
+    getPayFlow().setStripeAccount(stripeAccount);
+  }
+
+  @ReactMethod
   public void createTokenWithCard(final ReadableMap cardData, final Promise promise) {
     try {
       ArgCheck.nonNull(mStripe);

--- a/example/scripts/configure.sh
+++ b/example/scripts/configure.sh
@@ -2,4 +2,5 @@
 
 sed -i.bak 's@<PUBLISHABLE_KEY>@'"$PUBLISHABLE_KEY"'@' src/Root.js
 sed -i.bak 's@<MERCHANT_ID>@'"$MERCHANT_ID"'@' src/Root.js
+sed -i.bak 's@<STRIPE_ACCOUNT>@'"$STRIPE_ACCOUNT"'@' src/Root.js
 rm -rf src/Root.js.bak

--- a/example/src/Root.js
+++ b/example/src/Root.js
@@ -19,6 +19,8 @@ stripe.setOptions({
   androidPayMode: 'test',
 })
 
+stripe.setStripeAccount('<STRIPE_ACCOUNT>')
+
 export default class Root extends PureComponent {
   state = {
     index: 0,

--- a/example/src/Root.js
+++ b/example/src/Root.js
@@ -19,7 +19,10 @@ stripe.setOptions({
   androidPayMode: 'test',
 })
 
-stripe.setStripeAccount('<STRIPE_ACCOUNT>')
+const connectedAccount = '<STRIPE_ACCOUNT>';
+if (connectedAccount != '') {
+  stripe.setStripeAccount(connectedAccount)
+}
 
 export default class Root extends PureComponent {
   state = {

--- a/ios/TPSStripe/TPSStripeManager.m
+++ b/ios/TPSStripe/TPSStripeManager.m
@@ -143,6 +143,10 @@ RCT_EXPORT_METHOD(init:(NSDictionary *)options errorCodes:(NSDictionary *)errors
     [Stripe setDefaultPublishableKey:publishableKey];
 }
 
+RCT_EXPORT_METHOD(setStripeAccount:(NSString *)stripeAccount) {
+    [[STPAPIClient sharedClient] setStripeAccount:stripeAccount];
+}
+
 RCT_EXPORT_METHOD(deviceSupportsApplePay:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
     resolve(@([PKPaymentAuthorizationViewController canMakePayments]));

--- a/src/Stripe.js
+++ b/src/Stripe.js
@@ -21,6 +21,10 @@ class Stripe {
     return StripeModule.init(options, errorCodes)
   }
 
+  setStripeAccount = (stripeAccount) => (
+    StripeModule.setStripeAccount(stripeAccount)
+  )
+
   // @deprecated use deviceSupportsNativePay
   deviceSupportsAndroidPay = () => (
     StripeModule.deviceSupportsAndroidPay()

--- a/website/docs-md/usage.md
+++ b/website/docs-md/usage.md
@@ -23,3 +23,12 @@ stripe.setOptions({
 `androidPayMode` _String_ (Android only) - Corresponds to [WALLET_ENVIRONMENT](https://developers.google.com/android/reference/com/google/android/gms/wallet/WalletConstants
 ).
 Can be one of: `test|production`.
+
+
+### Usage with Stripe Connect
+
+If you're using Connect and need to set a `stripeAccount` do the following:
+
+```js
+stripe.setStripeAccount('<ACCT_>')
+```


### PR DESCRIPTION
## Proposed changes
Expose the `setStripeAccount` method for both iOS and Android so developers can use it with Stripe Connect accounts.
Fixes https://github.com/tipsi/tipsi-stripe/issues/533 and https://github.com/tipsi/tipsi-stripe/issues/118

## Types of changes
- [ ] Bugfix (a non-breaking change which fixes an issue)  
- [x] New feature (a non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

## Checklist
- [ ] I have added tests that prove my fix is useful or that my feature works  
- [x] I have added necessary documentation (if appropriate)  
- [x] I know that my PR will be merged only if it has tests and they pass  
