### PR TITLE
Treat `requires_capture` as a successful confirmPaymentIntent

### DIFF
--- a/ios/TPSStripe/TPSStripeManager.m
+++ b/ios/TPSStripe/TPSStripeManager.m
@@ -494,7 +494,7 @@ RCT_EXPORT_METHOD(confirmSetupIntent:(NSDictionary<NSString*, id> *)untypedParam
                                    return;
                                }
 
-                               if (intent.status == STPSetupIntentStatusSucceeded) {
+                               if (intent.status == STPSetupIntentStatusSucceeded || intent.status == STPPaymentIntentStatusRequiresCapture) {
                                    self->requestIsCompleted = YES;
                                    [self resolvePromise: [self convertConfirmSetupIntentResult: intent]];
                                } else if (intent.status == STPSetupIntentStatusRequiresAction) {


### PR DESCRIPTION
Treats PaymentIntents that end up with `requires_capture` as their status as a successful call to `confirmPaymentIntent`.

This PR only currently implements this for iOS. @mindlapse please let me know if you agree with this (and the discussion in Discord), and what needs to be done for Android.