### PR TITLE
Expose userInfo with stripe error details for android

### DIFF
--- a/android/src/main/java/com/gettipsi/stripe/Errors.java
+++ b/android/src/main/java/com/gettipsi/stripe/Errors.java
@@ -1,9 +1,14 @@
 package com.gettipsi.stripe;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeMap;
 import com.gettipsi.stripe.util.ArgCheck;
+import com.stripe.android.exception.APIException;
+import com.stripe.android.exception.CardException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -53,4 +58,33 @@ public final class Errors {
     return errorCodes.getMap(errorKey).getString("description");
   }
 
+  static WritableMap toUserInfo(@NonNull Exception exception) {
+    return toUserInfo(exception, new WritableNativeMap());
+  }
+
+  private static WritableMap toUserInfo(@Nullable Throwable throwable, @NonNull WritableMap userInfo) {
+    if (throwable == null) return userInfo;
+
+    if (throwable instanceof APIException) {
+      return toUserInfo(throwable.getCause(), userInfo);
+    }
+
+    if (throwable instanceof CardException) {
+      final CardException cardException = (CardException) throwable;
+      userInfo.putString("com.stripe.lib:ErrorMessageKey", cardException.getMessage());
+      userInfo.putString("com.stripe.lib:ErrorParameterKey", cardException.getParam());
+      userInfo.putString("com.stripe.lib:StripeErrorCodeKey", cardException.getCode());
+      userInfo.putString("com.stripe.lib:StripeErrorTypeKey", cardException.getStripeError() != null ? cardException.getStripeError().type : null);
+    }
+
+    if (throwable instanceof InvalidRequestException) {
+      final InvalidRequestException invalidRequestException = (InvalidRequestException) throwable;
+      userInfo.putString("com.stripe.lib:ErrorMessageKey", invalidRequestException.getMessage());
+      userInfo.putString("com.stripe.lib:ErrorParameterKey", invalidRequestException.getParam());
+      userInfo.putString("com.stripe.lib:StripeErrorCodeKey", invalidRequestException.getErrorCode());
+      userInfo.putString("com.stripe.lib:StripeErrorTypeKey", invalidRequestException.getStripeError() != null ? invalidRequestException.getStripeError().type : null);
+    }
+
+    return userInfo;
+  }
 }

--- a/android/src/main/java/com/gettipsi/stripe/StripeModule.java
+++ b/android/src/main/java/com/gettipsi/stripe/StripeModule.java
@@ -50,6 +50,7 @@ import static com.gettipsi.stripe.Errors.UNEXPECTED;
 import static com.gettipsi.stripe.Errors.getDescription;
 import static com.gettipsi.stripe.Errors.getErrorCode;
 import static com.gettipsi.stripe.Errors.toErrorCode;
+import static com.gettipsi.stripe.Errors.toUserInfo;
 import static com.gettipsi.stripe.util.Converters.convertPaymentIntentResultToWritableMap;
 import static com.gettipsi.stripe.util.Converters.convertPaymentMethodToWritableMap;
 import static com.gettipsi.stripe.util.Converters.convertSetupIntentResultToWritableMap;
@@ -201,11 +202,11 @@ public class StripeModule extends ReactContextBaseJavaModule {
           }
           public void onError(Exception error) {
             error.printStackTrace();
-            promise.reject(toErrorCode(error), error.getMessage());
+            promise.reject(toErrorCode(error), error.getMessage(), toUserInfo(error));
           }
         });
     } catch (Exception e) {
-      promise.reject(toErrorCode(e), e.getMessage());
+      promise.reject(toErrorCode(e), e.getMessage(), toUserInfo(e));
     }
   }
 
@@ -225,11 +226,11 @@ public class StripeModule extends ReactContextBaseJavaModule {
           }
           public void onError(Exception error) {
             error.printStackTrace();
-            promise.reject(toErrorCode(error), error.getMessage());
+            promise.reject(toErrorCode(error), error.getMessage(), toUserInfo(error));
           }
         });
     } catch (Exception e) {
-      promise.reject(toErrorCode(e), e.getMessage());
+      promise.reject(toErrorCode(e), e.getMessage(), toUserInfo(e));
     }
   }
 
@@ -247,7 +248,7 @@ public class StripeModule extends ReactContextBaseJavaModule {
       cardDialog.setPromise(promise);
       cardDialog.show(currentActivity.getFragmentManager(), "AddNewCard");
     } catch (Exception e) {
-      promise.reject(toErrorCode(e), e.getMessage());
+      promise.reject(toErrorCode(e), e.getMessage(), toUserInfo(e));
     }
   }
 
@@ -289,7 +290,7 @@ public class StripeModule extends ReactContextBaseJavaModule {
           public void onError(@NonNull Exception e) {
             getReactApplicationContext().removeActivityEventListener(ael);
             e.printStackTrace();
-            promise.reject(toErrorCode(e), e.getMessage());
+            promise.reject(toErrorCode(e), e.getMessage(), toUserInfo(e));
           }
         });
       }
@@ -340,7 +341,7 @@ public class StripeModule extends ReactContextBaseJavaModule {
           public void onError(@NonNull Exception e) {
             getReactApplicationContext().removeActivityEventListener(ael);
             e.printStackTrace();
-            promise.reject(toErrorCode(e), e.getMessage());
+            promise.reject(toErrorCode(e), e.getMessage(), toUserInfo(e));
           }
         });
       }
@@ -405,7 +406,7 @@ public class StripeModule extends ReactContextBaseJavaModule {
 
       @Override
       public void onError(Exception error) {
-        promise.reject(toErrorCode(error), error.getMessage());
+        promise.reject(toErrorCode(error), error.getMessage(), toUserInfo(error));
       }
 
       @Override
@@ -426,7 +427,7 @@ public class StripeModule extends ReactContextBaseJavaModule {
     mStripe.createSource(sourceParams, new SourceCallback() {
       @Override
       public void onError(Exception error) {
-        promise.reject(toErrorCode(error));
+        promise.reject(toErrorCode(error), error.getMessage(), toUserInfo(error));
       }
 
       @Override


### PR DESCRIPTION
## Proposed changes
To handle stripe errors in the app correctly it is necessary to receive the Stripe error code within the ReactNative App. For iOS this is possible through the `userInfo` field contained in the occurring error. This PR adds the same userInfo to the errors for Android.

This will fix following Issues:
#130
#373

## Types of changes
What types of changes does your code introduce to `tipsi-stripe`?  
_Put an `x` in the boxes that apply_

- [x] Bugfix (a non-breaking change which fixes an issue)  
- [ ] New feature (a non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! Next steps are a reminder of what we are going to look at before merging your code._

- [ ] I have added tests that prove my fix is useful or that my feature works  
- [ ] I have added necessary documentation (if appropriate)  
- [ ] I know that my PR will be merged only if it has tests and they pass  

