### PR TITLE
Android: Upgrade to latest stripe-android on the 10.4 line

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,7 +47,7 @@ dependencies {
   implementation 'com.android.support:appcompat-v7:28.0.0'
   implementation "com.google.android.gms:play-services-wallet:$googlePlayServicesVersion"
   implementation "com.google.firebase:firebase-core:$firebaseVersion"
-  implementation 'com.stripe:stripe-android:10.2.1'
+  implementation 'com.stripe:stripe-android:10.4.5'
   implementation 'com.github.tipsi:CreditCardEntry:1.5.1'
 }
 repositories {


### PR DESCRIPTION
Discussed in the Discord, stripe-android had some bugs when certain flows were triggered by some banks. Some of which were fixed in 10.4.4. 

Since this was fixed in the "old-code-line" I think stripe-android team thinks this is serious enough to strongly suggest we update. So here we go.

We could instead update to the 11.x code-line. Not sure if the breaking changes affect us!