### PR TITLE
Android: Allow requires_confirmation success state on android

### DIFF
--- a/android/src/main/java/com/gettipsi/stripe/StripeModule.java
+++ b/android/src/main/java/com/gettipsi/stripe/StripeModule.java
@@ -271,7 +271,8 @@ public class StripeModule extends ReactContextBaseJavaModule {
             StripeIntent.Status resultingStatus = result.getIntent().getStatus();
 
             if (Succeeded.equals(resultingStatus) ||
-                RequiresCapture.equals(resultingStatus)) {
+                RequiresCapture.equals(resultingStatus) ||
+                RequiresConfirmation.equals(resultingStatus)) {
               promise.resolve(convertPaymentIntentResultToWritableMap(result));
             } else {
               if (Canceled.equals(resultingStatus) ||

--- a/android/src/main/java/com/gettipsi/stripe/StripeModule.java
+++ b/android/src/main/java/com/gettipsi/stripe/StripeModule.java
@@ -276,8 +276,7 @@ public class StripeModule extends ReactContextBaseJavaModule {
               promise.resolve(convertPaymentIntentResultToWritableMap(result));
             } else {
               if (Canceled.equals(resultingStatus) ||
-                  RequiresAction.equals(resultingStatus) ||
-                  RequiresConfirmation.equals(resultingStatus)
+                  RequiresAction.equals(resultingStatus)
               ) {
                 promise.reject(CANCELLED, CANCELLED);      // TODO - normalize the message
               } else {


### PR DESCRIPTION
Partially discussed last week, and raised/elaborated by adrien.teulade-pod-point in Discord today (Tuesday, Sept 17).

On iOS if `handleNextAction` (the 3dSecure flow) returns success, then we return the intent to the app regardless of the status in `intent.status`, which means `requires_confirmation` gets returned to the app. 

This is currently mostly for use with `authenticatePaymentIntent`.