### PR TITLE
Stripe Connect Support: Add setStripeAccount.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,7 +47,7 @@ dependencies {
   implementation 'com.android.support:appcompat-v7:28.0.0'
   implementation "com.google.android.gms:play-services-wallet:$googlePlayServicesVersion"
   implementation "com.google.firebase:firebase-core:$firebaseVersion"
-  implementation 'com.stripe:stripe-android:10.4.5'
+  implementation 'com.stripe:stripe-android:10.4.6'
   implementation 'com.github.tipsi:CreditCardEntry:1.5.1'
 }
 repositories {

--- a/android/src/main/java/com/gettipsi/stripe/StripeModule.java
+++ b/android/src/main/java/com/gettipsi/stripe/StripeModule.java
@@ -187,6 +187,16 @@ public class StripeModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void setStripeAccount(final String stripeAccount) {
+    ArgCheck.notEmptyString(mPublicKey);
+    if (stripeAccount == null) {
+      mStripe = new Stripe(getReactApplicationContext(), mPublicKey);
+    } else {
+      mStripe = new Stripe(getReactApplicationContext(), mPublicKey, stripeAccount);
+    }
+  }
+
+  @ReactMethod
   public void createTokenWithCard(final ReadableMap cardData, final Promise promise) {
     try {
       ArgCheck.nonNull(mStripe);

--- a/example/scripts/configure.sh
+++ b/example/scripts/configure.sh
@@ -6,6 +6,7 @@ echo "BACKEND_URL is set to '$BACKEND_URL'"
 
 sed -i.bak 's@<PUBLISHABLE_KEY>@'"$PUBLISHABLE_KEY"'@' src/Root.js
 sed -i.bak 's@<MERCHANT_ID>@'"$MERCHANT_ID"'@' src/Root.js
+sed -i.bak 's@<STRIPE_ACCOUNT>@'"$STRIPE_ACCOUNT"'@' src/Root.js
 sed -i.bak 's@<BACKEND_URL>@'"$BACKEND_URL"'@' src/scenes/PaymentIntentScreen.js
 sed -i.bak 's@<BACKEND_URL>@'"$BACKEND_URL"'@' src/scenes/SetupIntentScreen.js
 rm -rf src/Root.js.bak

--- a/example/src/Root.js
+++ b/example/src/Root.js
@@ -21,6 +21,9 @@ stripe.setOptions({
   androidPayMode: 'test',
 })
 
+// can also be set to null if you want to clear
+stripe.setStripeAccount('<STRIPE_ACCOUNT>')
+
 export default class Root extends PureComponent {
   state = {
     index: 0,

--- a/ios/TPSStripe/TPSStripeManager.m
+++ b/ios/TPSStripe/TPSStripeManager.m
@@ -259,6 +259,7 @@ void initializeTPSPaymentNetworksWithConditionalMappings() {
     NSString *publishableKey;
     NSString *merchantId;
     NSDictionary *errorCodes;
+    NSString *stripeAccount;
 
     RCTPromiseResolveBlock promiseResolver;
     RCTPromiseRejectBlock promiseRejector;
@@ -302,6 +303,10 @@ RCT_EXPORT_METHOD(init:(NSDictionary *)options errorCodes:(NSDictionary *)errors
     merchantId = options[@"merchantId"];
     errorCodes = errors;
     [Stripe setDefaultPublishableKey:publishableKey];
+}
+
+RCT_EXPORT_METHOD(setStripeAccount:(NSString *)_stripeAccount) {
+    stripeAccount = _stripeAccount;
 }
 
 RCT_EXPORT_METHOD(deviceSupportsApplePay:(RCTPromiseResolveBlock)resolve
@@ -1292,6 +1297,7 @@ RCT_EXPORT_METHOD(openApplePaySetup) {
 
     STPAPIClient * client = [[STPAPIClient alloc] initWithPublishableKey:[Stripe defaultPublishableKey]];
     client.appInfo = info;
+    client.stripeAccount = stripeAccount;
 
     // Singleton sharedHandler should have the matching API Client!
     STPPaymentHandler.sharedHandler.apiClient = client;

--- a/tipsi-stripe.podspec
+++ b/tipsi-stripe.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.source_files   = 'ios/TPSStripe/**/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'Stripe', '>= 16.0.7'
+  s.dependency 'Stripe', '>= 19.0.1'
 end

--- a/website/docs-md/usage.md
+++ b/website/docs-md/usage.md
@@ -23,3 +23,16 @@ stripe.setOptions({
 `androidPayMode` _String_ (Android only) - Corresponds to [WALLET_ENVIRONMENT](https://developers.google.com/android/reference/com/google/android/gms/wallet/WalletConstants
 ).
 Can be one of: `test|production`.
+
+### Usage with Stripe Connect	
+
+If you're using [Stripe Connect](https://stripe.com/docs/connect) and need to set a `stripeAccount` do the following:	
+
+```js
+stripe.setStripeAccount('<ACCT_>');	
+```
+
+when you're done doing operations on the stripe connected account do:
+```js
+stripe.setStripeAccount(null);
+```


### PR DESCRIPTION
Adds Stripe Connect Support.
new JS method `setStripeAccount` which can be an account id or null.

## Proposed changes
This adds needed support for Stripe Connect:
https://stripe.com/docs/connect/
It is implemented in a similar way to the official javascript package, see:
https://stripe.com/docs/stripe-js/reference

## Types of changes
What types of changes does your code introduce to `tipsi-stripe`?  
_Put an `x` in the boxes that apply_

- [ ] Bugfix (a non-breaking change which fixes an issue)  
- [x] New feature (a non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! Next steps are a reminder of what we are going to look at before merging your code._

- [ ] I have added tests that prove my fix is useful or that my feature works  
- [x] I have added necessary documentation (if appropriate)  
- [ ] I know that my PR will be merged only if it has tests and they pass  

## Further comments
This adds a secondary setup option if you are using a connectedAccount
`setStripeAccount`
I am also happy to add tests but I don't see any tests that hit the Native Modules. Please give me some direction in terms of how to unit test this. It would be easy to confirm on a mock HTTP object that the stripe account has been added to the headers.
This has been tested live in iOS and Android and is working great.
