### PR TITLE
feat(website): add DocSearch as recommended by docusaurus.

### DIFF
--- a/website/docs/siteConfig.js
+++ b/website/docs/siteConfig.js
@@ -38,6 +38,10 @@ const siteConfig = {
   highlight: { theme: 'default' },
   scripts: ['https://buttons.github.io/buttons.js'],
   repoUrl: 'https://github.com/tipsi/tipsi-stripe',
+  algolia: {
+    apiKey: '3f8ac9b9932eef475114a7db0665311f',
+    indexName: 'tipsi-stripe',
+  }
 }
 
 module.exports = siteConfig


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.