### PR TITLE
Bugfix/fix compilation error on ios for 8.0.0.beta9

### DIFF
--- a/ios/TPSStripe/TPSStripeManager.m
+++ b/ios/TPSStripe/TPSStripeManager.m
@@ -126,7 +126,7 @@ RCT_ENUM_CONVERTER(STPPaymentMethodType,
         case STPPaymentMethodTypeCard: return @"card";
         case STPPaymentMethodTypeiDEAL: return @"iDEAL";
         case STPPaymentMethodTypeCardPresent: return @"card_present";
-        case STPPaymentMethodTypeFPX: return @"unknown";
+        case STPPaymentMethodTypeFPX: // unsupported at this time (fall through)
         case STPPaymentMethodTypeUnknown:
         default: return @"unknown";
     }

--- a/ios/TPSStripe/TPSStripeManager.m
+++ b/ios/TPSStripe/TPSStripeManager.m
@@ -126,7 +126,7 @@ RCT_ENUM_CONVERTER(STPPaymentMethodType,
         case STPPaymentMethodTypeCard: return @"card";
         case STPPaymentMethodTypeiDEAL: return @"iDEAL";
         case STPPaymentMethodTypeCardPresent: return @"card_present";
-        case STPPaymentMethodTypeFPX: return @"fpx";
+        case STPPaymentMethodTypeFPX: return @"unknown";
         case STPPaymentMethodTypeUnknown:
         default: return @"unknown";
     }


### PR DESCRIPTION
## Proposed changes
@cybergrind, please have a look at this PR. this is a fix to issue [Issue 585](https://github.com/tipsi/tipsi-stripe/issues/585)

Currently, user on Xcode could not build tipsi-stripe version 8.0.0.beta9 because a typo here:

case STPPaymentMethodTypeFPX: return @"fpx";

fpx is not currently supported, it should be marked as type unknown rather than fpx.

## Types of changes
What types of changes does your code introduce to `tipsi-stripe`?  
_Put an `x` in the boxes that apply_

- [x] Bugfix (a non-breaking change which fixes an issue)  
- [ ] New feature (a non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! Next steps are a reminder of what we are going to look at before merging your code._

- [ ] I have added tests that prove my fix is useful or that my feature works  
- [ ] I have added necessary documentation (if appropriate)  
- [x] I know that my PR will be merged only if it has tests and they pass  

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you choose the solution you did and what alternatives you considered.
