### PR TITLE
Fix billing address

### DIFF
--- a/android/src/main/java/com/gettipsi/stripe/StripeModule.java
+++ b/android/src/main/java/com/gettipsi/stripe/StripeModule.java
@@ -574,12 +574,12 @@ public class StripeModule extends ReactContextBaseJavaModule {
 
     if (billingDetailsParams != null) {
 
-      ReadableMap addressParams = getMapOrNull(options, "address");
+      ReadableMap addressParams = getMapOrNull(billingDetailsParams, "address");
 
       if (addressParams != null) {
         address = new Address.Builder().
           setCity(getStringOrNull(addressParams, "city")).
-          setCountry(addressParams.getString("country")).
+          setCountry(getStringOrNull(addressParams, "country")).
           setLine1(getStringOrNull(addressParams, "line1")).
           setLine2(getStringOrNull(addressParams, "line2")).
           setPostalCode(getStringOrNull(addressParams, "postalCode")).

--- a/ios/TPSStripe/TPSStripeManager.m
+++ b/ios/TPSStripe/TPSStripeManager.m
@@ -958,8 +958,9 @@ RCT_EXPORT_METHOD(openApplePaySetup) {
     if (!params) {return nil;}
 
     STPPaymentMethodBillingDetails * result = [[STPPaymentMethodBillingDetails alloc] init];
+    STPPaymentMethodAddress * address = [self extractPaymentMethodBillingDetailsAddressFromDictionary: params[TPSStripeParam(PaymentMethodBillingDetails, address)]];
 #define simpleUnpack(key) result.key = [RCTConvert NSString:params[TPSStripeParam(PaymentMethodBillingDetails, key)]]
-    result.address = params[TPSStripeParam(PaymentMethodBillingDetails, address)];
+    result.address = address;
     simpleUnpack(email);
     simpleUnpack(name);
     simpleUnpack(phone);


### PR DESCRIPTION
## Proposed changes

Currently, when create payment method, the `address` under `billing_details` is not posted in iOS and Android.

iOS:
- Fix address to use `STPPaymentMethodAddress`.

Android:
- Fix `addressParams` lookup at wrong map
- Change address builder's `setCountry` to accepts nullable

## Types of changes
What types of changes does your code introduce to `tipsi-stripe`?  
_Put an `x` in the boxes that apply_

- [x] Bugfix (a non-breaking change which fixes an issue)  
- [ ] New feature (a non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! Next steps are a reminder of what we are going to look at before merging your code._

- [ ] I have added tests that prove my fix is useful or that my feature works  
- [ ] I have added necessary documentation (if appropriate)  
- [x] I know that my PR will be merged only if it has tests and they pass  

