### PR TITLE
add support to Metadata in function createSourceWithParams

### DIFF
--- a/android/src/main/java/com/gettipsi/stripe/StripeModule.java
+++ b/android/src/main/java/com/gettipsi/stripe/StripeModule.java
@@ -4,8 +4,8 @@ import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.AsyncTask;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.facebook.react.bridge.ActivityEventListener;
@@ -17,6 +17,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
+import com.facebook.react.bridge.ReadableType;
 import com.gettipsi.stripe.dialog.AddCardDialogFragment;
 import com.gettipsi.stripe.util.ArgCheck;
 import com.gettipsi.stripe.util.Converters;
@@ -425,13 +426,57 @@ public class StripeModule extends ReactContextBaseJavaModule {
     });
   }
 
+  /**
+   * toMap converts a {@link ReadableMap} into a HashMap.
+   *
+   * @param readableMap The ReadableMap to be converted.
+   * @return A HashMap containing the data that was in the ReadableMap.
+   */
+  public static Map<String, String> toMap(@Nullable ReadableMap readableMap) {
+    if (readableMap == null) {
+      return null;
+    }
+
+    com.facebook.react.bridge.ReadableMapKeySetIterator iterator = readableMap.keySetIterator();
+    if (!iterator.hasNextKey()) {
+      return null;
+    }
+
+    Map<String, String> result = new HashMap<>();
+    while (iterator.hasNextKey()) {
+      String key = iterator.nextKey();
+      ReadableType type = readableMap.getType(key);
+      switch(type) {
+        case Null:
+          break;
+        case Boolean:
+
+          break;
+        case Number:
+
+          break;
+        case String:
+          result.put(key, readableMap.getString(key));
+          break;
+        default:
+          throw new IllegalArgumentException("Unsupported type " + type);
+      }
+    }
+
+    return result;
+  }
+
 
   @ReactMethod
   public void createSourceWithParams(final ReadableMap options, final Promise promise) {
 
     SourceParams sourceParams = extractSourceParams(options);
-
+    Map<String,String> metadata=toMap(getMapOrNull(options,"metadata"));
     ArgCheck.nonNull(sourceParams);
+
+    sourceParams.setMetaData(metadata);
+
+
 
     mStripe.createSource(sourceParams, new SourceCallback() {
       @Override

--- a/ios/TPSStripe/TPSStripeManager.m
+++ b/ios/TPSStripe/TPSStripeManager.m
@@ -711,6 +711,8 @@ RCT_EXPORT_METHOD(createSourceWithParams:(NSDictionary *)params
         sourceParams = [STPSourceParams cardParamsWithCard:[self extractCardParamsFromDictionary:params]];
     }
 
+    sourceParams.metadata = params[@"metadata"];
+
     STPAPIClient* stripeAPIClient = [self newAPIClient];
 
     [stripeAPIClient createSourceWithParams:sourceParams completion:^(STPSource *source, NSError *error) {


### PR DESCRIPTION
## Proposed changes
Add the metadata support in the function createSourceWithParams.
Currently metadata is not accepted in this function so its not allowed developer to add something like orderId to the source.
With this change the the metadata can be added to all kind of source in both IOS and Android.
The related issue is #636 

## Types of changes
What types of changes does your code introduce to `tipsi-stripe`?  
_Put an `x` in the boxes that apply_

- [x] Bugfix (a non-breaking change which fixes an issue)  
- [ ] New feature (a non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! Next steps are a reminder of what we are going to look at before merging your code._

- [ ] I have added tests that prove my fix is useful or that my feature works  
- [ ] I have added necessary documentation (if appropriate)  
- [ ] I know that my PR will be merged only if it has tests and they pass  

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you choose the solution you did and what alternatives you considered.
