### PR TITLE
Fix version number for the latest update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [8.0.0-beta.10] - 2020-10-02
+## [8.0.0-beta.11] - 2020-10-02
 
 - Fix ios billing address [#640](https://github.com/tipsi/tipsi-stripe/pull/640)
 


### PR DESCRIPTION
No code changes, just a quick typo fix on the changelog:
Latest release was 8.0.0-beta.10 instead of 8.0.0-beta.11