### PR TITLE
Bug Fix: stripe account id not being sent when authenticatePaymentInt…

### DIFF
--- a/ios/TPSStripe/TPSStripeManager.m
+++ b/ios/TPSStripe/TPSStripeManager.m
@@ -451,6 +451,8 @@ RCT_EXPORT_METHOD(authenticatePaymentIntent:(NSDictionary<NSString*, id> *)untyp
     promiseResolver = resolve;
     promiseRejector = reject;
 
+    [[STPPaymentHandler sharedHandler] setApiClient: self.newAPIClient];
+
     // From example in step 3 of https://stripe.com/docs/payments/payment-intents/ios#manual-confirmation-ios
     [[STPPaymentHandler sharedHandler] handleNextActionForPayment:clientSecret
                                         withAuthenticationContext:self


### PR DESCRIPTION
…ent called

## Proposed changes
when using 'custom' connect accounts there is a need to use the stripeAccount header to confirm/authenticate payment intents. The below fixes an issue where the authenticatePaymentIntent would not pass the 'stripeAccount' causing a no such payment intent error. 

Our flow / steps to reproduce:

- create a 'stripe' instance using tipsi stripe and only set publishable key (platforms)
- create a payment method (use SCA card) and send to server
- have the server swap this for a 'shared' payment method.
- create payment method / try to confirm it (using manual confirmation)
- send back clientSecret to UI
- 'setStripeAccount' on tipsi stripe instance to connect accounts id
- try to authenticate the payment intent

above will cause no such payment intent error

## Types of changes

- [ x] Bugfix (a non-breaking change which fixes an issue)  
- [ ] New feature (a non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

## Further comments
The above has not had any tests added to verify, in fact this issue is most likely only 'half' resolved as 'authenticateSetupIntent' most likely needs something similar as well, we dont use this so cant verify at the moment.
