### PR TITLE
Allow native payment request for an amount of 0

### DIFF
--- a/docs/docs/errorcodes.html
+++ b/docs/docs/errorcodes.html
@@ -470,7 +470,7 @@
                         </tr>
                         <tr>
                           <td style="text-align:left"><strong>noAmount</strong></td>
-                          <td style="text-align:left">Amount should be greater than 0</td>
+                          <td style="text-align:left">Amount should not be less than zero</td>
                         </tr>
                         <tr>
                           <td style="text-align:left"><strong>parseResponse</strong></td>

--- a/ios/TPSStripe/TPSStripeManager.m
+++ b/ios/TPSStripe/TPSStripeManager.m
@@ -1199,7 +1199,7 @@ RCT_EXPORT_METHOD(openApplePaySetup) {
         reject(error[kErrorKeyCode], error[kErrorKeyDescription], nil);
         return NO;
     }
-    if ([[[paymentRequest.paymentSummaryItems lastObject] amount] floatValue] == 0) {
+    if ([[[paymentRequest.paymentSummaryItems lastObject] amount] floatValue] < 0) {
         NSDictionary *error = [errorCodes valueForKey:kErrorKeyNoAmount];
         reject(error[kErrorKeyCode], error[kErrorKeyDescription], nil);
         return NO;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tipsi-stripe",
-  "version": "8.0.0-beta.10",
+  "version": "8.0.0-beta.11",
   "description": "React Native Stripe binding for iOS/Android platforms",
   "main": "src/index.js",
   "scripts": {

--- a/src/errorCodes.js
+++ b/src/errorCodes.js
@@ -46,7 +46,7 @@ const errorCodes = {
   },
   noAmount: {
     errorCode: 'noAmount',
-    description: 'Amount should be greater than 0',
+    description: 'Amount should not be less than zero',
   },
   parseResponse: {
     errorCode: 'parseResponse',

--- a/website/docs-md/errorcodes.md
+++ b/website/docs-md/errorcodes.md
@@ -17,7 +17,7 @@ sidebar_label: Error Codes
 | **sourceStatusUnknown** | Source polling unknown error |
 | **noPaymentRequest** | Missing payment request |
 | **noMerchantIdentifier** | Missing merchant identifier |
-| **noAmount** | Amount should be greater than 0 |
+| **noAmount** | Amount should not be less than zero |
 | **parseResponse** | Failed to parse JSON |
 | **activityUnavailable** | Cannot continue with no current activity |
 | **playServicesUnavailable** | Play services are not available |


### PR DESCRIPTION
## Proposed changes
This pull request allows to make request payment for an amount of 0.

According to Apple's documentation, the amount can be equal to 0:
https://developer.apple.com/documentation/apple_pay_on_the_web/applepaypaymentrequest/1916119-total

This changes are based on the tag: `8.0.0-beta.11`

## Types of changes
Instead of preventing payment request of 0 from being fired, this will now change the check to prevent requests if the amount is less than 0.

- [ ] Bugfix (a non-breaking change which fixes an issue)  
- [x] New feature (a non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

## Checklist
- [ ] I have added tests that prove my fix is useful or that my feature works  
- [x] I have added necessary documentation (if appropriate)  
- [x] I know that my PR will be merged only if it has tests and they pass  

## Further comments
Here is a screenshot while testing these changes with the "test" environment
![Screen Shot 2020-12-24 at 1 57 15 PM](https://user-images.githubusercontent.com/10536110/103917584-9d6d5e00-50c2-11eb-857d-f73a70ea1935.png)
