### PR TITLE
fix react native imports for webpack

### DIFF
--- a/src/components/PaymentCardTextField.js
+++ b/src/components/PaymentCardTextField.js
@@ -9,7 +9,9 @@ import {
   Platform,
 } from 'react-native'
 import PropTypes from 'prop-types'
-import TextInputState from 'react-native/Libraries/Components/TextInput/TextInputState'
+import { TextInput } from 'react-native';
+
+const { State: TextInputState } = TextInput;
 
 const FieldStylePropType = PropTypes.shape({
   ...ViewPropTypes.style,
@@ -215,4 +217,3 @@ const styles = StyleSheet.create({
     height: 44,
   },
 })
-

--- a/src/utils/processTheme.js
+++ b/src/utils/processTheme.js
@@ -1,4 +1,4 @@
-import processColor from 'react-native/Libraries/StyleSheet/processColor'
+import { processColor } from "react-native"
 
 export default function processTheme(theme = {}) {
   return Object.keys(theme).reduce((result, key) => {


### PR DESCRIPTION
## Proposed changes
Fixing incorrect relative imports from React Native which break packagers. Ironically these never seemed to break metro but they did break webpack.

## Types of changes
What types of changes does your code introduce to `tipsi-stripe`?  

- [x] Bugfix (a non-breaking change which fixes an issue)  

## Checklist
None of the below. I have not tested these fixes yet. I am getting them out there first. Webpack seems to compile the project now.

- [ ] I have added tests that prove my fix is useful or that my feature works  
- [ ] I have added necessary documentation (if appropriate)  
- [ ] I know that my PR will be merged only if it has tests and they pass  


