### PR TITLE
chore: bump stripe-ios to v21

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,12 +1,12 @@
-# Use iOS 9 and above
-platform :ios, '9.0'
+# Use iOS 11 and above
+platform :ios, '11.0'
 
 # Specify Workspace
 workspace 'example'
 
 target 'example' do
   # Stripe
-  pod 'Stripe', '~> 19.4.0'
+  pod 'Stripe', '~> 21.3.1'
 
   # Install additional dependencies
   pod 'Firebase/Core'

--- a/example/ios/example/AppDelegate.m
+++ b/example/ios/example/AppDelegate.m
@@ -11,7 +11,7 @@
 
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
-#import <Stripe/Stripe.h>
+@import Stripe;
 
 @implementation AppDelegate
 
@@ -41,7 +41,7 @@
 
 // This method handles opening native URLs (e.g., "yourexampleapp://")
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
-  BOOL stripeHandled = [Stripe handleStripeURLCallbackWithURL:url];
+  BOOL stripeHandled = [StripeAPI handleStripeURLCallbackWithURL:url];
   if (stripeHandled) {
     return YES;
   } else {

--- a/ios/TPSStripe/TPSCardField.h
+++ b/ios/TPSStripe/TPSCardField.h
@@ -7,7 +7,7 @@
 //
 
 #import <React/UIView+React.h>
-#import <Stripe/Stripe.h>
+@import Stripe;
 
 @interface TPSCardField : UIView
 

--- a/ios/TPSStripe/TPSStripeManager.h
+++ b/ios/TPSStripe/TPSStripeManager.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <PassKit/PassKit.h>
-#import <Stripe/Stripe.h>
+@import Stripe;
 #import <React/RCTBridgeModule.h>
 #import <React/RCTConvert.h>
 

--- a/ios/TPSStripe/TPSStripeManager.m
+++ b/ios/TPSStripe/TPSStripeManager.m
@@ -9,7 +9,7 @@
 #import "TPSStripeManager.h"
 #import <React/RCTUtils.h>
 #import <React/RCTConvert.h>
-#import <Stripe/Stripe.h>
+@import Stripe;
 
 #import "TPSError.h"
 #import "TPSStripeManager+Constants.h"
@@ -302,7 +302,7 @@ RCT_EXPORT_METHOD(init:(NSDictionary *)options errorCodes:(NSDictionary *)errors
     publishableKey = options[@"publishableKey"];
     merchantId = options[@"merchantId"];
     errorCodes = errors;
-    [Stripe setDefaultPublishableKey:publishableKey];
+    [StripeAPI setDefaultPublishableKey:publishableKey];
 }
 
 RCT_EXPORT_METHOD(setStripeAccount:(NSString *)_stripeAccount) {
@@ -853,7 +853,7 @@ RCT_EXPORT_METHOD(paymentRequestWithApplePay:(NSArray *)items
         [summaryItems addObject:summaryItem];
     }
 
-    PKPaymentRequest *paymentRequest = [Stripe paymentRequestWithMerchantIdentifier:merchantId country:countryCode currency:currencyCode];
+    PKPaymentRequest *paymentRequest = [StripeAPI paymentRequestWithMerchantIdentifier:merchantId country:countryCode currency:currencyCode];
 
     [paymentRequest setRequiredShippingAddressFields:requiredShippingAddressFields];
     [paymentRequest setRequiredBillingAddressFields:requiredBillingAddressFields];
@@ -1184,7 +1184,7 @@ RCT_EXPORT_METHOD(openApplePaySetup) {
 }
 
 - (BOOL)canSubmitPaymentRequest:(PKPaymentRequest *)paymentRequest rejecter:(RCTPromiseRejectBlock)reject {
-    if (![Stripe deviceSupportsApplePay]) {
+    if (![StripeAPI deviceSupportsApplePay]) {
         NSDictionary *error = [errorCodes valueForKey:kErrorKeyDeviceNotSupportsNativePay];
         reject(error[kErrorKeyCode], error[kErrorKeyDescription], nil);
         return NO;
@@ -1210,9 +1210,7 @@ RCT_EXPORT_METHOD(openApplePaySetup) {
 
 #pragma mark - STPAddCardViewControllerDelegate
 
-- (void)addCardViewController:(STPAddCardViewController *)addCardViewController
-       didCreatePaymentMethod:(STPPaymentMethod *)paymentMethod
-                   completion:(STPErrorBlock)completion {
+- (void)addCardViewController:(STPAddCardViewController *)addCardViewController didCreatePaymentMethod:(STPPaymentMethod *)paymentMethod completion:(void (^)(NSError * _Nullable))completion {
     [RCTPresentedViewController() dismissViewControllerAnimated:YES completion:nil];
 
     requestIsCompleted = YES;
@@ -1296,7 +1294,7 @@ RCT_EXPORT_METHOD(openApplePaySetup) {
                                             url:TPSAppInfoURL];
     });
 
-    STPAPIClient * client = [[STPAPIClient alloc] initWithPublishableKey:[Stripe defaultPublishableKey]];
+    STPAPIClient * client = [[STPAPIClient alloc] initWithPublishableKey:[StripeAPI defaultPublishableKey]];
     client.appInfo = info;
     client.stripeAccount = stripeAccount;
 
@@ -1489,7 +1487,7 @@ RCT_EXPORT_METHOD(openApplePaySetup) {
             return @"discover";
         case STPCardBrandDinersClub:
             return @"diners";
-        case STPCardBrandMasterCard:
+        case STPCardBrandMastercard:
             return @"mastercard";
         case STPCardBrandUnknown:
         default:
@@ -1499,7 +1497,7 @@ RCT_EXPORT_METHOD(openApplePaySetup) {
 
 /// API: https://stripe.com/docs/api/cards/object#card_object-brand
 - (NSString *)cardBrandAsPresentableBrandString:(STPCardBrand)inputBrand {
-    return STPStringFromCardBrand(inputBrand);
+    return [STPCard stringFromBrand:inputBrand];
 }
 
 - (NSString *)cardFunding:(STPCardFundingType)inputFunding {
@@ -1598,7 +1596,7 @@ RCT_EXPORT_METHOD(openApplePaySetup) {
             return @"bancontact";
         case STPSourceTypeGiropay:
             return @"giropay";
-        case STPSourceTypeIDEAL:
+        case STPSourceTypeiDEAL:
             return @"ideal";
         case STPSourceTypeSEPADebit:
             return @"sepaDebit";

--- a/tipsi-stripe.podspec
+++ b/tipsi-stripe.podspec
@@ -13,11 +13,11 @@ Pod::Spec.new do |s|
   s.source         = { :git => 'https://github.com/tipsi/tipsi-stripe', :tag => s.version }
 
   s.requires_arc   = true
-  s.platform       = :ios, '9.0'
+  s.platform       = :ios, '11.0'
 
   s.preserve_paths = 'LICENSE', 'README.md'
   s.source_files   = 'ios/TPSStripe/**/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'Stripe', '>= 19.0.1'
+  s.dependency 'Stripe', '>= 21.3.1'
 end


### PR DESCRIPTION
As we're still waiting for Stripe's official RN library, our build [stopped working with Xcode 12.5](https://github.com/stripe/stripe-ios/issues/1764). Stripe backported a patch to v14, 15, and 17, but kept back the [backport to v19](https://github.com/stripe/stripe-ios/issues/1767) which is the version used in tipsi-stripe.

Therefore, I decided to follow the migration guide and make tipsi-stripe use the most current stripe-ios sdk (21.3.1). 

I actually don't know whether new releases for tipsi-stripe are planned at all, but otherwise feel free to check out my branch directly (`npm install repo#branch` is your friend).