### PR TITLE
Fix incorrect changelog date in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ npm run build-docs
 
 [Full changelog](/CHANGELOG.md)
 
-[[8.0.0] - 2019-01-08 **Breaking changes**](/CHANGELOG.md#800---2021-01-16)
+[[8.0.0] - 2021-01-16 **Breaking changes**](/CHANGELOG.md#800---2021-01-16)
 
 [[7.0.0] - 2019-01-08 **Breaking changes**](/CHANGELOG.md#700---2019-01-08)
 


### PR DESCRIPTION
## Proposed changes

Only a README typo fix; presumably a copy/paste error. 

## Types of changes
- [ ] Bugfix (a non-breaking change which fixes an issue)  
- [ ] New feature (a non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

## Checklist
- [ ] I have added tests that prove my fix is useful or that my feature works  
- [x] I have added necessary documentation (if appropriate)  
- [ ] I know that my PR will be merged only if it has tests and they pass  

## Further comments
Although minor, the current README would suggest the latest major version was released in 2019 which doesn't highlight how up-to-date this package is.
