### PR TITLE
[Android payment intent] Replace "failed" error message by proper Stripe code & message 

### DIFF
--- a/android/src/main/java/com/gettipsi/stripe/StripeModule.java
+++ b/android/src/main/java/com/gettipsi/stripe/StripeModule.java
@@ -290,7 +290,12 @@ public class StripeModule extends ReactContextBaseJavaModule {
               ) {
                 promise.reject(CANCELLED, CANCELLED);      // TODO - normalize the message
               } else {
-                promise.reject(result.getIntent().getLastPaymentError().declineCode, result.getIntent().getLastPaymentError().message);
+                if (result.getIntent().getLastPaymentError().declineCode == null) {
+                  promise.reject(result.getIntent().getLastPaymentError().code, result.getIntent().getLastPaymentError().message);
+                } else {
+                  promise.reject(result.getIntent().getLastPaymentError().declineCode, result.getIntent().getLastPaymentError().message);
+                }
+
               }
             }
           }

--- a/android/src/main/java/com/gettipsi/stripe/StripeModule.java
+++ b/android/src/main/java/com/gettipsi/stripe/StripeModule.java
@@ -290,7 +290,7 @@ public class StripeModule extends ReactContextBaseJavaModule {
               ) {
                 promise.reject(CANCELLED, CANCELLED);      // TODO - normalize the message
               } else {
-                promise.reject(FAILED, FAILED);
+                promise.reject(result.getIntent().getLastPaymentError().declineCode, result.getIntent().getLastPaymentError().message);
               }
             }
           }


### PR DESCRIPTION
## Proposed changes
The idea here is when a payment intent fails, to get for example "insufficient_funds" as error code whereas "failed". This could be very helpful for people who need to make extra process when a 3DS payment fails. 
I'm not very comfortable with objective C so if anyone could do the same on iOS side, it would be absolutely great !!
Thank you and thank you for your work :) 
Have an amazing day 

## Types of changes
What types of changes does your code introduce to `tipsi-stripe`?  
_Put an `x` in the boxes that apply_

- [ ] Bugfix (a non-breaking change which fixes an issue)  
- [x] New feature (a non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! Next steps are a reminder of what we are going to look at before merging your code._

- [ ] I have added tests that prove my fix is useful or that my feature works  
- [ ] I have added necessary documentation (if appropriate)  
- [ ] I know that my PR will be merged only if it has tests and they pass  

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you choose the solution you did and what alternatives you considered.
