### PR TITLE
docs: updated docs

### DIFF
--- a/website/docs-md/changelog.md
+++ b/website/docs-md/changelog.md
@@ -4,11 +4,277 @@ title: Changelog
 sidebar_label: Changelog
 ---
 
-This project adheres to [Semantic Versioning](http://semver.org/).  
-Every release, along with the migration instructions, is documented on the Github [Releases](https://github.com/tipsi/tipsi-stripe/releases/) page.
+This project adheres to [Semantic Versioning](http://semver.org/).
 
-[[5.2.0] - 2018-04-04](https://github.com/tipsi/tipsi-stripe/releases/tag/5.2.0)
+## [9.0.0] - 2021-03-24
 
-[[5.1.0] - 2018-03-28](https://github.com/tipsi/tipsi-stripe/releases/tag/5.1.0)
+- [#741](https://github.com/tipsi/tipsi-stripe/pull/741)
+- [#730](https://github.com/tipsi/tipsi-stripe/pull/730) ios: bump stripe-ios to v21
 
-[[5.0.0] - 2018-03-21 **Breaking changes**](https://github.com/tipsi/tipsi-stripe/releases/tag/5.0.0)
+## [8.0.1] - 2021-01-17
+
+- [#710](https://github.com/tipsi/tipsi-stripe/pull/710) Android: japanese translation
+
+## [8.0.0] - 2021-01-16
+
+### Android
+
+- Compile SDK Version increased from 26 -> 28
+- Target SDK Version increased from 26 -> 28
+- Min SDK Version increased from 16 -> 19
+- Support libraries increased from 27.1.0 to 28.0.0
+- `stripe-android` upgraded from 8.1.0 to 10.4.0
+
+### iOS
+
+- Minimum compatible `stripe-ios` sdk -> 16.0.7, but recommended 17.0.1 or later (update your `Podfile` or vendored `stripe-ios`!)
+- Xcode version: recommended 10.3.1 or later
+
+### New SCA-ready APIs
+
+- `stripe.createPaymentMethod(…)`
+- `stripe.confirmPaymentIntent(…)`
+- `stripe.confirmSetupIntent(…)`
+- `stripe.authenticatePaymentIntent(…)` (only used with manual confirmation mode)
+- `stripe.potentiallyAvailableNativePayNetworks(…)`
+
+### Common
+
+- **Breaking** The Card form now returns a PaymentMethod. The Card form will no longer return a token (or Source)
+- **Warning** Supports React Native 59.x (*other versions at your own risk*)
+- JSDoc-annotated API Descriptions for the new APIs
+- Helper methods `stripe.slugForCardBrand(…)` and `stripe.presentableStringForCardBrand(…)` to normalize Card Brand Strings that change values depending on which API you're working with. (Stripe API oddity)
+
+### Bug fixes
+
+- Prevented toErrorCode from itself causing an error
+
+### Examples
+
+- The example app has new PaymentIntent and SetupIntent screens that can be used to test various card scenarios
+- The example app requires a backend for those screens, which can be forked and one-click deployed to Heroku from:
+  - [mindlapse/example-tipsi-stripe-backend](https://github.com/mindlapse/example-tipsi-stripe-backend)
+  - You need to set the environment variable BACKEND_URL to the location it is deployed
+
+### Dev tooling
+
+- Added .circleci config
+- Added eslint & prettier config
+
+
+## [7.5.0] - 2019-04-22
+
+- [Google pay: capture email](https://github.com/tipsi/tipsi-stripe/pull/469)
+- [Add translations for German, Dutch, Italian and Spanish.](https://github.com/tipsi/tipsi-stripe/pull/464)
+- android: update CreditCardEntry:1.5.1
+
+## [7.4.0] - 2019-02-25
+
+- [Switch from compile to implementation in gradle file](https://github.com/tipsi/tipsi-stripe/pull/438)
+
+## [7.3.0] - 2019-02-15
+- [Call reject directly in createSourceWithParams](https://github.com/tipsi/tipsi-stripe/pull/433)
+
+## [7.2.0] - 2019-01-29
+- Remove broken imports
+
+## [7.1.0] - 2019-01-14
+- Fixed issue [#232](https://github.com/tipsi/tipsi-stripe/issues/232) Added card type for source creation ([#261](https://github.com/tipsi/tipsi-stripe/pull/261))
+
+## [7.0.0] - 2018-10-28
+- Update iOS Stripe SDK to 14.0.0
+- Update Android Stripe SDK to 8.1.0
+- Fix [unassigned promise rejector bug](https://github.com/tipsi/tipsi-stripe/issues/372)
+
+## [6.1.0] - 2018-10-28
+- Update CreditCardEntry to 1.4.10
+
+## [6.0.0] - 2018-10-24
+- Update iOS Stripe SDK to 13.2.0
+- Update iOS deployment target to 9.0
+- Update Android Stripe SDK to 8.0.0
+
+## [5.6.0] - 2018-08-22
+### Added
+- [Common error codes](https://tipsi.github.io/tipsi-stripe/docs/errorcodes.html). Part of them provided by `tipsi-stripe`, another part by `Stripe` itself.
+
+## [5.5.1] - 2018-08-10
+### Added
+- `paymentRequestWithAndroidPay` now supports _boolean_ `phone_number_required` field to ask a user for phone number  
+
+## [5.5.0] - 2018-08-08
+### Added
+- `tipsi-stripe` now respects [project-level GMS version](https://github.com/tipsi/tipsi-stripe/pull/350) on Android 
+
+## [5.4.0] - 2018-07-27
+From this release we are starting unify our Public API.  
+There was a difference between iOS and Android API, now we've created new methods that currently work as a proxy.  
+So, we have marked deprecated methods inside `src/Stripe.js`, and yes there is no more Stripe.${platform}.js files.  
+But, you won't see any changes. Breaking changes will be introduced in version 6.
+
+### DEPRECATED METHODS
+- `deviceSupportsAndroidPay` and `deviceSupportsApplePay` => `deviceSupportsNativePay`
+- `canMakeAndroidPayPayments` and `canMakeApplePayPayments` => `canMakeNativePayPayments`
+- `paymentRequestWithAndroidPay` and `paymentRequestWithApplePay` => `paymentRequestWithNativePay`
+- `completeApplePayRequest` => `completeNativePayRequest` (Android implementation doesn't exist)
+- `cancelApplePayRequest` => `cancelNativePayRequest` (Android implementation doesn't exist)
+- `openApplePaySetup` => `openNativePaySetup` (Android implementation doesn't exist)
+
+As you can see all platform specific methods are now unified.  
+We called them `Native Methods` because `Google/Android Pay` and `ApplePay` are native payments systems unlike Credit Cards.  
+
+### Changed
+- `Stripe.ios.js` and `Stripe.android.js` => `Stripe.js`
+- Native iOS `TPSStripeManager` renamed to `StripeModule`
+- Example App now uses new unified methods
+
+## [5.3.0] - 2018-07-23
+### Changed
+- `REACT_CLASS` for Native Android implementation of PaymentCardTextField renamed `CreditCardForm => TPSCardField`
+- `PaymentCardTextField` merged into one compoment. It's a first step to clearing the difference between iOS and Android
+- `Android Pay => Google Pay` in `android/src/main/res/values/strings.xml`
+- `prop-types` in example updated `15.5.10 => 15.6.1`, appium `1.8.0 => 1.8.1`
+
+### Added
+- Default string value for Cancel button in Card Form `gettipsi_card_enter_dialog_negative_button`
+- Support `overflow` style property on PaymentCardTextField (now it has <View /> wrapper inside)
+
+### Removed
+- Obsolete AndroidPay flow
+
+## [5.2.4] - 2018-06-28
+### Added
+- Added missing `{number|expiration|cvc}Placeholder` fields to iOS' `<PaymentCardTextField />`
+
+## [5.2.3] - 2018-06-07
+### Changed
+- Removed `package.json` from tipsi-stripe's podspec `preserve_paths` (to enable adding this pod via a `:git` key without hitting npm/yarn considering it a js package)
+
+## [5.2.2] - 2018-06-01
+### Changed
+- Fixed int LOAD_PAYMENT_DATA_REQUEST_CODE in GoogleApiPayFlowImpl.java (< 65535)
+
+## [5.2.1] - 2018-05-05
+### Added
+- Fixed an error with PropTypes
+
+## [5.2.0] - 2018-04-04
+### Added 
+- Method `stripe.canMakeAndroidPayPayments()` checks if gpay supported and user has existing payment method
+
+### Changed
+- Method `stripe.deviceSupportsAndroidPay()` doesn’t require anymore user to have existing payment method
+
+## [5.1.0] - 2018-03-28
+### Changed
+- Method `deviceSupportAndroidPay()` now also checks if google pay has at least one existing payment method (for example user attached his card before)
+
+## [5.0.0] - 2018-03-21
+### Breaking changes:
+
+#### 1) Initialization
+ 
+before 5.0.0: 
+
+```javascript
+// somewhere in the app start section
+  
+stripe.init({
+  merchantId: '<MERCHANT_ID>',
+  publishableKey: '<PUB_KEY>',
+  androidPayMode: 'test',      
+})
+  
+stripe.paymentRequestWithAndroidPay(paymentOptions)
+```
+
+after 5.0.0:
+
+##### single-step initialization
+
+```javascript
+// same as above except used method name
+  
+stripe.setOptions({
+  merchantId: '<MERCHANT_ID>',
+  publishableKey: '<PUB_KEY>',
+  androidPayMode: 'test',      
+})
+  
+stripe.paymentRequestWithAndroidPay(paymentOptions)
+```
+
+##### multi-step initialization
+```javascript
+// somewhere in the app start section
+// make sure you've set androidPayMode before using androidPay related methods i.e.
+// stripe.deviceSupportsAndroidPay()
+// stripe.paymentRequestWithAndroidPay()
+// or runtime exception will be thrown
+  
+stripe.setOptions({
+  androidPayMode: 'test',      
+})
+  
+// somewhere else later i.e. near store cart code
+stripe.setOptions({
+  publishableKey: '<PUB_KEY>',
+})
+  
+// make sure you've set *all* needed options before, both androidPayMode and publishableKey
+// or exception will be thrown
+  
+stripe.paymentRequestWithAndroidPay(paymentOptions)
+```
+
+#### 2) billing/shipping address requirement
+before 5.0.0:
+```javascript
+// you couldn't before set billing_address_required, shipping_address_required options
+// to require user filling that data. shipping_address_required was true by default
+// and such data was missing in the method response (useless user input)
+  
+stripe.paymentRequestWithAndroidPay(paymentOptions)
+```
+
+after 5.0.0:
+```javascript
+
+// explicitly set required input from user by
+// setting billing_address_required, shipping_address_required props,
+// omitted values are false by default
+  
+const addressRequirements = {
+  billing_address_required: false,
+  shipping_address_required: true,
+}
+  
+stripe.paymentRequestWithAndroidPay({
+  paymentOptions,
+  ...addressRequirements,
+})
+```
+
+### Added
+- Modern GooglePay [api](https://developers.google.com/pay/api/setup) was used by default
+- `shippingContact`, `billingContact` appear are in results of `paymentRequestWithAndroidPay()`
+- Firebase dependency appears
+- More strict runtime argument checks
+
+### Changed
+- Method `setOptions()` performs multi-step initialization and used instead of `init()`. Options `publishableKey`, `androidPayMode` are settable at runtime. If method requires presence of options that are unset, runtime exception will be thrown. Special case: `androidPayMode` re-init is forbidden and **leads to runtime exception**.
+- Wallet api version bump
+- AndroidPay flow extracted from `StripeModule`
+- Better naming
+- Only create api client on demand
+- Extract commons to utils
+- Avoid copy and paste in old code
+
+### Removed
+- Obsolete AndroidPay flow is disabled by default and will be removed soon
+
+### Fixed
+- Fix of [Android Pay Shipping address not working](https://github.com/tipsi/tipsi-stripe/issues/240)
+- Avoid `StripeModule` Activity NPE
+- Avoid bugs regarding options default values
+- Fix leaked promise bug

--- a/website/docs-md/createCardOrSubscription.md
+++ b/website/docs-md/createCardOrSubscription.md
@@ -9,15 +9,15 @@ sidebar_label: Save Card/Subscription
 You will need to store and use cards on your backend server.
 
 
-1. `tipsi-stripe` will only generate token that will be used by backend to create card object. Use [API](./createtokenwithcard.html) to create token
-2. Send it to your backend server where it can save it using [Stripe API to create card](https://stripe.com/docs/api/cards/create)
+1. `tipsi-stripe` will only generate token that will be used by backend to create card object. Use [API](./createtokenwithcard.html) to create token.
+2. Send it to your backend server where it can save it using [Stripe API to create card](https://stripe.com/docs/api/cards/create).
 3. Save response in your database and then you will be able to reuse saved card token to make payments. Add some description to help user to select this card in the future (last4, name).
-4. Add API on the backend side that will return list of your descriptions with ids
-5. Use this id to get `CardToken` and use card token instead of one time token when performing payments
+4. Add API on the backend side that will return list of your descriptions with ids.
+5. Use this id to get `CardToken` and use card token instead of one time token when performing payments.
 
 
 When you've saved the card on your backend you may use it to create subscriptions via [Stripe API](https://stripe.com/docs/billing/subscriptions/creating).
 
-If you are using `PaymentIntents` you can use instructions from [SCA](./paymentIntents.html#the-user-is-saving-a-card-for-future-use)
+If you are using `PaymentIntents` you can use instructions from [SCA](./paymentIntents.html#the-user-is-saving-a-card-for-future-use).
 
-How to use ApplePay with recurring subscriptions https://support.stripe.com/questions/use-apple-pay-for-recurring-payments
+How to use ApplePay with recurring subscriptions https://support.stripe.com/questions/use-apple-pay-for-recurring-payments.

--- a/website/docs-md/createsourcewithparamsparams.md
+++ b/website/docs-md/createsourcewithparamsparams.md
@@ -4,11 +4,11 @@ title: .createSourceWithParams(params) -> Promise
 sidebar_label: .createSourceWithParams()
 ---
 
-Creates source object based on params. Sources are used to create payments for a variety of [payment methods](https://stripe.com/docs/sources)
+Creates source object based on params. Sources are used to create payments for a variety of [payment methods](https://stripe.com/docs/sources).
 
-_NOTE_: For sources that require redirecting your customer to authorize the payment, you need to specify a return URL when you create the source. This allows your customer to be redirected back to your app after they have authorized the payment. For this return URL, you can either use a custom URL scheme or a universal link supported by your app.
+**_NOTE_**: For sources that require redirecting your customer to authorize the payment, you need to specify a return URL when you create the source. This allows your customer to be redirected back to your app after they have authorized the payment. For this return URL, you can either use a custom URL scheme or a universal link supported by your app.
 
-##### iOS
+### iOS
 
 For more information on registering and handling URLs in your app, refer to the Apple documentation:
 
@@ -17,7 +17,7 @@ For more information on registering and handling URLs in your app, refer to the 
 
 You also need to setup your `AppDelegate.m` app delegate to forward URLs to the Stripe SDK according to the [official iOS implementation](https://stripe.com/docs/mobile/ios/sources#redirecting-your-customer).
 
-##### Android
+### Android
 
 You have to declare your return url in application's `build.gradle` file.
 In order to do that, add the following code replacing `CUSTOM_SCHEME` with the your custom scheme inside the `android.defaultConfig` block.
@@ -36,7 +36,7 @@ android {
 ```
 > Example: if the return URL used is `my_custom_scheme://callback`, replace `CUSTOM_SCHEME` with `my_custom_scheme`.
 
-**NOTE**: the redirection will be automatically handled by tipsi-stripe **on its own activity**.
+**_NOTE_**: the redirection will be automatically handled by tipsi-stripe **on its own activity**.
 If your app makes use of its own custom URL scheme for other purpose than handling stripe payments, make sure that the `CUSTOM_SCHEME` value is not exactly the same as the one used in the rest of the app.
 
 > In such a case you might end up using `my_custom_scheme_tipsi://callback` as return URL and setting `CUSTOM_SCHEME` equal to `my_custom_scheme_tipsi`, following the previous example.
@@ -60,7 +60,7 @@ xmlns:tools="http://schemas.android.com/tools"
 ```
 as an attribute into the root node of your manifest.
 
-**NOTE**: This is **only** necessary if you are going to use Sources!
+**_NOTE_**: This is **only** necessary if you are going to use Sources!
 
 
 `params` — An object with the following keys:

--- a/website/docs-md/google-pay.md
+++ b/website/docs-md/google-pay.md
@@ -25,8 +25,8 @@ After that, API team will send you confirmation from `googlepay-api-support@goog
 When everything is done with a test application, you will need to enable the application by:
 
 
-* Please have the account owner login to <OWNER@EMAIL.HERE> and access our [sign-up link](https://payments.developers.google.com/signup)
-* To ensure you are logged into the right account, click [here](https://accounts.google.com/SignOutOptions?continue=https://payments.developers.google.com/signup)
+* Please have the account owner login to <OWNER@EMAIL.HERE> and access our [sign-up link](https://payments.developers.google.com/signup).
+* To ensure you are logged into the right account, click [here](https://accounts.google.com/SignOutOptions?continue=https://payments.developers.google.com/signup).
 * Complete a profile, then on the next page, scroll down to Enable applications and they’ll see the package name.
 * Only click Enable next to the corresponding package name and confirm with me once this has been completed.
 * Once complete, your selected APK has production access, and you can configure your Android  application to point to Environment_Production.

--- a/website/docs-md/index.md
+++ b/website/docs-md/index.md
@@ -9,7 +9,7 @@ sidebar_label: Start here
 
 * Xcode 8+
 
-* iOS 10+
+* iOS 11+
 
 * [CocoaPods](https://cocoapods.org) 1.1.1+
 
@@ -19,9 +19,9 @@ sidebar_label: Start here
 
 ## Testing Payments
 
-Credit Cards: you can use real cards for payments on test environment without hesitation. You won't be charged on test environment for card payments.
+**Credit Cards**: you can use real cards for payments on test environment without hesitation. You won't be charged on test environment for card payments.
 
-Or you can use [test cards provided by stripe](https://stripe.com/docs/testing#cards)
+Or you can use [test cards provided by stripe](https://stripe.com/docs/testing#cards).
 
-Google Pay: will charge you for $1 but return money soon (~1hr)
+**Google Pay**: will charge you for $1 but return money soon (~1hr).
 

--- a/website/docs-md/installation.md
+++ b/website/docs-md/installation.md
@@ -18,6 +18,8 @@ yarn add tipsi-stripe
 
 Setup your `Podfile` like the included [example/ios/Podfile](https://github.com/tipsi/tipsi-stripe/blob/master/example/ios/Podfile) then run `pod install`.
 
+If your React Native version is < `0.60`, then:
+
 1. Open your project in Xcode workspace.
 2. Drag the following folder into your project:
    * `node_modules/tipsi-stripe/ios/TPSStripe/`

--- a/website/docs-md/linking.md
+++ b/website/docs-md/linking.md
@@ -6,9 +6,16 @@ sidebar_label: Linking
 
 > **Note** Linking on Windows system currently isn't working. Feel free to fix it and remove this warning from docs
 
-## Automatically
 
-Run `react-native link tipsi-stripe` so your project is linked against your Xcode project and all CocoaPods dependencies are installed.
+## React Native >= 0.60
+
+Autolinking will just do the job.
+
+## React Native < 0.60
+
+## Automatic
+
+`react-native link tipsi-stripe`
 
 ## Manual
 
@@ -34,7 +41,7 @@ In your `android/app/build.gradle` add:
 ...
 dependencies {
   ...
-+ compile project(':tipsi-stripe')
++ implementation project(':tipsi-stripe')
 }
 ```
 
@@ -54,8 +61,8 @@ In your `android/build.gradle` add:
 
 allprojects {
   repositories {
-  ...
-+ maven { url "https://jitpack.io" }
+    ...
++   maven { url "https://jitpack.io" }
   }
 }
 ```

--- a/website/docs-md/migrate.md
+++ b/website/docs-md/migrate.md
@@ -29,8 +29,8 @@ module.exports = {
 https://github.com/react-native-community/discussions-and-proposals/issues/129
 https://github.com/facebook/react-native-fbsdk/issues/429
 
-4. For build Android before building app use Jetify. 
-Run 
+4. For Android, before building the app, run [Jetifier](https://www.npmjs.com/package/jetifier):
+
 ```bash
 npx jetify
 ```
@@ -40,7 +40,7 @@ npx react-native run-android
 
 ## Troubleshooting 
 
-####Android
+#### Android
 
 Issue:
 ```

--- a/website/docs-md/paymentIntents.md
+++ b/website/docs-md/paymentIntents.md
@@ -6,7 +6,7 @@ sidebar_label: Payment Intent API
 
 ## Introduction
 
-Card payments with Stripe should be performed with PaymentIntents.
+Card payments with Stripe should be performed with `PaymentIntents`.
 
 This API was created to handle modern payments, where the cardholder's bank may require
 the user to authenticate themselves with the bank before a payment can be authorized.  
@@ -17,12 +17,12 @@ by PSD2 which introduced [Strong Customer Authentication
 
 
 ---
-**tipsi-stripe** helps to support key parts of the payment experience, with sections on each below.
+**tipsi-stripe** helps to support key parts of the payment experience, with sections on each below:
 
-1) Creating a PaymentMethod (with card data, a card token, or a token from Google Pay / Apple Pay)
-2) Initiating a payment from the mobile app
-3) Asking the user to authenticate a transaction that was attempted off-session by you, the Merchant
-4) Saving a card for future use
+1) Creating a PaymentMethod (with card data, a card token, or a token from Google Pay / Apple Pay).
+2) Initiating a payment from the mobile app.
+3) Asking the user to authenticate a transaction that was attempted off-session by you, the Merchant.
+4) Saving a card for future use.
 ---
 
 
@@ -64,7 +64,7 @@ try {
 }
 ```
 
-Here are the PropTypes that defines the shape of what can be provided to createPaymentMethod:
+Here are the `PropTypes` that defines the shape of what can be provided to `createPaymentMethod`:
 ```js
 {
 
@@ -102,23 +102,23 @@ Here are the PropTypes that defines the shape of what can be provided to createP
 
 ## Initiating a payment from the mobile app
 
-To do this, make a call from your mobile app to [create a Payment Intent on your backend server](https://stripe.com/docs/api/payment_intents/create)
+To do this, make a call from your mobile app to [create a Payment Intent on your backend server](https://stripe.com/docs/api/payment_intents/create).
   * If you created the payment intent with `confirmation_method='manual'` then you're using
     a manual confirmation flow, and payment intents can only be confirmed from the backend
-    using the secret key.  Jump to the [**... with manual confirmation**](#with-manual-confirmation) section
+    using the secret key.  Jump to the [**... with manual confirmation**](#with-manual-confirmation) section.
   * Otherwise, if you created the payment intent without specifying `confirmation_method` or
     by setting `confirmation_method='automatic'` then you are using an automatic 
     confirmation flow.  In this flow, you can confirm (process) the payment intent right from
     the mobile app, and webhooks sent by Stripe will notify your backend of success.  This is
     the preferred flow.
-    Jump to the [**... with automatic confirmation**](#with-automatic-confirmation) section
+    Jump to the [**... with automatic confirmation**](#with-automatic-confirmation) section.
        
 
 ### ... with manual confirmation
 In this flow, follow these steps:
-  * Obtain a PaymentMethod (either one saved to the customer or a new one as described in the [Creating a PaymentMethod](#creating-a-paymentmethod) section.),
+  * Obtain a PaymentMethod (either one saved to the customer or a new one as described in the [Creating a PaymentMethod](#creating-a-paymentmethod) section).
   * Create a PaymentIntent on the backend, with the provided PaymentMethod and the amount.
-    * set `confirmation_method=manual` when creating the intent
+    * set `confirmation_method=manual` when creating the intent.
     * do **not** specify `off_session=true`, since these are steps for creating an on-session payment (a payment where the user is present).
   * Confirm the PaymentIntent on the backend.  If the PaymentIntent moves to a `succeeded` state, then that's it!  The payment was successful.
   * If the PaymentIntent status moves to `requires_action`, then return the `client_secret` of the PaymentIntent to the mobile app,
@@ -131,9 +131,9 @@ In this flow, follow these steps:
 
 ### ... with automatic confirmation
 In this flow, follow these steps:
-  * Obtain a PaymentMethod (either one saved to the customer or a new one as described in the [Creating a PaymentMethod](#creating-a-paymentmethod) section.),
+  * Obtain a PaymentMethod (either one saved to the customer or a new one as described in the [Creating a PaymentMethod](#creating-a-paymentmethod) section).
   * Create a PaymentIntent on the backend, with the provided PaymentMethod and the amount.
-    * set `confirmation_method=automatic` when creating the intent (or omit it, since it is the default)
+    * set `confirmation_method=automatic` when creating the intent (or omit it, since it is the default).
     * do **not** specify `off_session=true`, since these are steps for creating an on-session payment (a payment where the user is present).
   * Call `await stripe.confirmPaymentIntent({ ... })`, passing in the client_secret.
     If an authentication is needed then an activity will be launched where the user can then authenticate the payment.
@@ -154,7 +154,7 @@ the user is brought into the app, you should, for the same PaymentIntent:
 
 1) Present the option to attempt the payment using the same card, or to provide a new one.
 2) Attach the selected card to the payment method to the PaymentIntent on the server side.
-3) Handle the payment as though it were an on-session payment.  See the section [Initiating a payment from the mobile app](#initiating-a-payment-from-the-mobile-app)
+3) Handle the payment as though it were an on-session payment.  See the section [Initiating a payment from the mobile app](#initiating-a-payment-from-the-mobile-app).
 
 
 

--- a/website/docs-md/paymentcardtextfield.md
+++ b/website/docs-md/paymentcardtextfield.md
@@ -53,7 +53,7 @@ You can also access the `valid` and `params` info via `<instance>.valid` and `<i
 # <PaymentCardTextField /> Component Example
 
 ```js
-import React, { Component } from 'react'
+import React, { PureComponent } from 'react'
 import { StyleSheet } from 'react-native'
 import { PaymentCardTextField } from 'tipsi-stripe'
 
@@ -67,7 +67,7 @@ const styles = StyleSheet.create({
   }
 })
 
-class FieldExample extends Component {
+class FieldExample extends PureComponent {
   handleFieldParamsChange = (valid, params) => {
     console.log(`
       Valid: ${valid}
@@ -89,18 +89,16 @@ class FieldExample extends Component {
   render() {
     return (
       <PaymentCardTextField
-        ref={ (ref) => {
-            this.paymentCardInput = ref;
-        }}
+        ref={(ref) => (this.paymentCardInput = ref)}
         style={styles.field}
-        cursorColor={...}
-        textErrorColor={...}
-        placeholderColor={...}
-        numberPlaceholder={...}
-        expirationPlaceholder={...}
-        cvcPlaceholder={...}
+        cursorColor={'blue'}
+        textErrorColor={'red'}
+        placeholderColor={'grey'}
+        numberPlaceholder={'4242'}
+        expirationPlaceholder={'MM/YY'}
+        cvcPlaceholder={'CVC'}
         disabled={false}
-        onParamsChange={this.handleFieldParamsChange}
+        onParamsChange={handleFieldParamsChange}
       />
     )
   }

--- a/website/docs-md/paymentrequestwithcardform.md
+++ b/website/docs-md/paymentrequestwithcardform.md
@@ -10,7 +10,7 @@ Opens the `Add Card` view to to accept a payment. On success the returned object
 
 | Key | Type | Description |
 | :--- | :--- | :--- |
-| requiredBillingAddressFields | String | The billing address fields the user must fill out when prompted for their payment details. Can be one of: **full || name || zip** or left unspecified to disable |
+| requiredBillingAddressFields | String | The billing address fields the user must fill out when prompted for their payment details. Can be one of: **full** ‖ **name** ‖ **zip** or left unspecified to disable |
 | prefilledInformation | Object | You can set this property to pre-fill any information you’ve already collected from your user |
 | theme | Object | Can be used to visually style Stripe-provided UI |
 

--- a/website/docs-md/token.md
+++ b/website/docs-md/token.md
@@ -25,8 +25,8 @@ A `token object` returned from submitting payment details to the Stripe API via:
 | Key | Type | Description |
 | :--- | :--- | :--- |
 | cardId | String | The Stripe ID for the card |
-| brand | String | The card’s brand. Can be one of: **JCB **‖ **American Express **‖ **Visa **‖ **Discover **‖ **Diners Club **‖ **MasterCard **‖ **Unknown** |
-| funding (iOS) | String | The card’s funding. Can be one of: **debit **‖ **credit **‖ **prepaid **‖ **unknown** |
+| brand | String | The card’s brand. Can be one of: **JCB** ‖ **American Express** ‖ **Visa** ‖ **Discover** ‖ **Diners Club** ‖ **MasterCard** ‖ **Unknown** |
+| funding (iOS) | String | The card’s funding. Can be one of: **debit** ‖ **credit** ‖ **prepaid** ‖ **unknown** |
 | last4 | String | The last 4 digits of the card |
 | dynamicLast4&nbsp;(iOS) | String | For cards made with Apple Pay, this refers to the last 4 digits of the Device Account Number for the tokenized card |
 | isApplePayCard&nbsp;(iOS) | Bool | Whether or not the card originated from Apple Pay |

--- a/website/docs/static/css/custom.css
+++ b/website/docs/static/css/custom.css
@@ -1,5 +1,7 @@
 /* your custom css */
 
+.mainContainer a { text-decoration: underline;}
+
 @media only screen and (min-device-width: 360px) and (max-device-width: 736px) {
 }
 


### PR DESCRIPTION
## Proposed changes
I have recently integrated `tipsi-stripe` into my project and I feel like the docs need some minor improvements. The proposed changes are:
- Fixed some markdown issues.
- Updated installation instructions. As of React Native 0.60+, no manual linking is needed.
- Updated minimum iOS version to 11+.
- Added `text-decoration: underline` for links in `mainContainer`. Links in the main container were not clearly visible and one could easily miss the link.
- Updated `PaymentCardTextField ` example to be ready to go example for copying and pasting instead of changing `...` before trying the example.
- Added periods(.) wherever needed.
- Added Changelogs as per mentioned in the [CHANGELOG.md](https://github.com/tipsi/tipsi-stripe/blob/master/CHANGELOG.md).

## Types of changes

- [ ] Bugfix (a non-breaking change which fixes an issue)  
- [ ] New feature (a non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected) 
- [x] Docs update

## Checklist

- [ ] I have added tests that prove my fix is useful or that my feature works  
- [x] I have added necessary documentation (if appropriate)  
- [ ] I know that my PR will be merged only if it has tests and they pass