### PR TITLE
Add nullcheck to name card parameter.

### DIFF
--- a/ios/TPSStripe/TPSStripeManager.m
+++ b/ios/TPSStripe/TPSStripeManager.m
@@ -899,7 +899,10 @@ RCT_EXPORT_METHOD(openApplePaySetup) {
     simpleUnpack(cvc);
 
     simpleUnpack(currency);
-    simpleUnpack(name);
+    NSObject *nameVal = params[@"name"];
+    if (nameVal != nil && ![nameVal isKindOfClass:[NSNull class]]) {
+        simpleUnpack(name);
+    }
 
 #undef simpleUnpack
 


### PR DESCRIPTION
## Proposed changes
Null check name parameter as missing name threw an exception when trying to convert it to a NString (simpleUnpack macro) when returning from 3DS check. 
## Types of changes
What types of changes does your code introduce to `tipsi-stripe`?  
_Put an `x` in the boxes that apply_

- [x] Bugfix (a non-breaking change which fixes an issue)  
- [ ] New feature (a non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! Next steps are a reminder of what we are going to look at before merging your code._

- [x] I have added tests that prove my fix is useful or that my feature works  
- [x] I have added necessary documentation (if appropriate)  
- [ x] I know that my PR will be merged only if it has tests and they pass  

## Further comments
This issue was discovered when trying to add credit cards with 3DS in a live environment (Swedish and Norwegian cards tested) but no crashes could be reproduced using stripe test cards. 
The issue seems so be that these live credit cards don't return credit card holder names for the cards. 
