### PR TITLE
implement createTokenWithBankAccount

### DIFF
--- a/android/src/main/java/com/gettipsi/stripe/StripeModule.java
+++ b/android/src/main/java/com/gettipsi/stripe/StripeModule.java
@@ -56,6 +56,7 @@ import static com.gettipsi.stripe.util.Converters.convertPaymentMethodToWritable
 import static com.gettipsi.stripe.util.Converters.convertSetupIntentResultToWritableMap;
 import static com.gettipsi.stripe.util.Converters.convertSourceToWritableMap;
 import static com.gettipsi.stripe.util.Converters.convertTokenToWritableMap;
+import static com.gettipsi.stripe.util.Converters.createBankAccountTokenParams;
 import static com.gettipsi.stripe.util.Converters.createCard;
 import static com.gettipsi.stripe.util.Converters.getBooleanOrNull;
 import static com.gettipsi.stripe.util.Converters.getMapOrNull;
@@ -225,6 +226,18 @@ public class StripeModule extends ReactContextBaseJavaModule {
     try {
       ArgCheck.nonNull(mStripe);
       ArgCheck.notEmptyString(mPublicKey);
+
+      mStripe.createBankAccountToken(
+        createBankAccountTokenParams(accountData),
+        new ApiResultCallback<Token>() {
+          public void onSuccess(Token token) {
+            promise.resolve(convertTokenToWritableMap(token));
+          }
+          public void onError(Exception error) {
+            error.printStackTrace();
+            promise.reject(toErrorCode(error), error.getMessage());
+          }
+      });
     } catch (Exception e) {
       promise.reject(toErrorCode(e), e.getMessage());
     }

--- a/android/src/main/java/com/gettipsi/stripe/util/Converters.java
+++ b/android/src/main/java/com/gettipsi/stripe/util/Converters.java
@@ -180,6 +180,28 @@ public class Converters {
     return allowedCountriesForShipping;
   }
 
+  public static BankAccountTokenParams.Type accountHolderTypeFromString(String value) {
+    if (value == "individual") {
+      return BankAccountTokenParams.Type.Individual;
+    }
+    if (value == "company") {
+      return BankAccountTokenParams.Type.Company;
+    }
+
+    return null;
+  }
+
+  public static BankAccountTokenParams createBankAccountTokenParams(final ReadableMap accountData) {
+    return new BankAccountTokenParams(
+      getValue(accountData, "countryCode"),
+      getValue(accountData, "currency"),
+      getValue(accountData, "accountNumber"),
+      accountHolderTypeFromString(getValue(accountData, "accountHolderType", "")),
+      getValue(accountData, "accountHolderName"),
+      getValue(accountData, "routingNumber")
+    );
+  }
+
   public static Card createCard(final ReadableMap cardData) {
     return new Card.Builder(
       cardData.getString("number"),

--- a/android/src/main/java/com/gettipsi/stripe/util/Converters.java
+++ b/android/src/main/java/com/gettipsi/stripe/util/Converters.java
@@ -181,10 +181,10 @@ public class Converters {
   }
 
   public static BankAccountTokenParams.Type accountHolderTypeFromString(String value) {
-    if (value == "individual") {
+    if (value.equals("individual")) {
       return BankAccountTokenParams.Type.Individual;
     }
-    if (value == "company") {
+    if (value.equals("company")) {
       return BankAccountTokenParams.Type.Company;
     }
 


### PR DESCRIPTION
## Proposed changes
It addresses https://github.com/tipsi/tipsi-stripe/issues/809

`createTokenWithBankAccount` misses the implementation for android, I suppose because the `stripe-android` package changed token creation from using a `BankAccount` to `BankAccountTokenParams` so it broke this library at some point.
This works as far as I've been able to see in the app I'm working on.

## Types of changes
What types of changes does your code introduce to `tipsi-stripe`?  
_Put an `x` in the boxes that apply_

- [x] Bugfix (a non-breaking change which fixes an issue)  
- [ ] New feature (a non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! Next steps are a reminder of what we are going to look at before merging your code._

- [ ] I have added tests that prove my fix is useful or that my feature works  
- [ ] I have added necessary documentation (if appropriate)  
- [ ] I know that my PR will be merged only if it has tests and they pass  

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you choose the solution you did and what alternatives you considered.
