### PR TITLE
Re-add card brand in Android Converter class

### DIFF
--- a/android/src/main/java/com/gettipsi/stripe/util/Converters.java
+++ b/android/src/main/java/com/gettipsi/stripe/util/Converters.java
@@ -19,6 +19,7 @@ import com.stripe.android.model.Address;
 import com.stripe.android.model.BankAccount;
 import com.stripe.android.model.BankAccountTokenParams;
 import com.stripe.android.model.Card;
+import com.stripe.android.model.CardBrand;
 import com.stripe.android.model.PaymentIntent;
 import com.stripe.android.model.PaymentMethod;
 import com.stripe.android.model.SetupIntent;
@@ -85,6 +86,8 @@ public class Converters {
 
     if (card == null) return result;
 
+    CardBrand brand = card.getBrand();
+
     result.putString("cardId", card.getId());
     result.putString("number", card.getNumber());
     result.putString("cvc", card.getCvc() );
@@ -97,6 +100,7 @@ public class Converters {
     result.putString("addressState", card.getAddressState() );
     result.putString("addressZip", card.getAddressZip() );
     result.putString("addressCountry", card.getAddressCountry() );
+    result.putString("brand", String.valueOf(brand) );
     result.putString("last4", card.getLast4() );
     result.putString("fingerprint", card.getFingerprint() );
     result.putString("country", card.getCountry() );


### PR DESCRIPTION
## Proposed changes
Card brand was removed from `convertCardToWritableMap` as the Stripe SDK nows returns a CardBrand object. This PR re-adds it, return the brand name as a string.

## Types of changes
What types of changes does your code introduce to `tipsi-stripe`?  
_Put an `x` in the boxes that apply_

- [x] Bugfix (a non-breaking change which fixes an issue)  
- [ ] New feature (a non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! Next steps are a reminder of what we are going to look at before merging your code._

- [ ] I have added tests that prove my fix is useful or that my feature works  
- [ ] I have added necessary documentation (if appropriate)  
- [ ] I know that my PR will be merged only if it has tests and they pass  

## Further comments
See issue #816 