### PR TITLE
Point users to @stripe/stripe-react-native, and add deprecation notices to: library, readme, docs, CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
+# 🚨 This library is no longer maintained 🚨
+
+If you're building apps with React Native, please use [Stripe's official React Native library](https://github.com/stripe/stripe-react-native).
+
 # tipsi-stripe
-
-This library isn't actively maintained now. Please, consider usage of Stripe's official library:
-
-https://github.com/stripe/stripe-react-native
-
 
 If for some reason you cannot migrate to it now. And you can offer with testing new beta versions, please reach me in [discord](https://discord.gg/vmBxnBw) (name: cybergrind#4625). Just PM with github account name + platforms you can check will be enough.
 I will ping you when we have something to check.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "prettier": "prettier",
-    "prettier:js": "prettier --write src/*.{js,jsx} src/**/*.{js,jsx} example/src/*.{js,jsx} example/src/**/*.{js,jsx}"
+    "prettier:js": "prettier --write src/*.{js,jsx} src/**/*.{js,jsx} example/src/*.{js,jsx} example/src/**/*.{js,jsx}",
+    "postinstall": "node postinstall.js"
   },
   "repository": {
     "type": "git",

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,4 @@
+/* eslint-disable no-console */
+console.warn(
+  '🚨 [tipsi-stripe] Deprecation notice: tipsi-stripe is no longer maintained. Please migrate your project to @stripe/stripe-react-native: https://github.com/stripe/stripe-react-native'
+);

--- a/src/index.js
+++ b/src/index.js
@@ -5,3 +5,8 @@ import errorCodes from './errorCodes'
 export { PaymentCardTextField, errorCodes }
 
 export default Stripe
+
+// eslint-disable-next-line no-console
+console.warn(
+  '🚨 [tipsi-stripe] Deprecation notice: tipsi-stripe is no longer maintained. Please migrate your project to @stripe/stripe-react-native: https://github.com/stripe/stripe-react-native'
+)

--- a/website/docs-md/index.md
+++ b/website/docs-md/index.md
@@ -1,27 +1,9 @@
 ---
 id: index
-title: Start here
-sidebar_label: Start here
+title: Deprecation Notice
+sidebar_label: Deprecation Notice
 ---
 
-## Library requirements
-### iOS
+## 🚨 Deprecation notice: please use `@stripe/stripe-react-native` 🚨
 
-* Xcode 8+
-
-* iOS 11+
-
-* [CocoaPods](https://cocoapods.org) 1.1.1+
-
-### Android
-
-* SDK 17+
-
-## Testing Payments
-
-**Credit Cards**: you can use real cards for payments on test environment without hesitation. You won't be charged on test environment for card payments.
-
-Or you can use [test cards provided by stripe](https://stripe.com/docs/testing#cards).
-
-**Google Pay**: will charge you for $1 but return money soon (~1hr).
-
+This library is no longer maintained. Please update your project to use [`@stripe/stripe-react-native`](https://github.com/stripe/stripe-react-native)

--- a/website/docs-md/start.md
+++ b/website/docs-md/start.md
@@ -1,0 +1,31 @@
+---
+id: start
+title: (Deprecated) Start here
+sidebar_label: (Deprecated) Start here
+---
+
+## 🚨 Deprecation notice: please use `@stripe/stripe-react-native` 🚨
+
+This library is no longer maintained. Please update your project to use [`@stripe/stripe-react-native`](https://github.com/stripe/stripe-react-native)
+
+## Library requirements
+
+### iOS
+
+- Xcode 8+
+
+- iOS 11+
+
+- [CocoaPods](https://cocoapods.org) 1.1.1+
+
+### Android
+
+- SDK 17+
+
+## Testing Payments
+
+**Credit Cards**: you can use real cards for payments on test environment without hesitation. You won't be charged on test environment for card payments.
+
+Or you can use [test cards provided by stripe](https://stripe.com/docs/testing#cards).
+
+**Google Pay**: will charge you for \$1 but return money soon (~1hr).

--- a/website/docs/i18n/en.json
+++ b/website/docs/i18n/en.json
@@ -3,7 +3,7 @@
   "localized-strings": {
     "next": "Next",
     "previous": "Previous",
-    "tagline": "Stripe support for React-Native",
+    "tagline": "(Deprecated) Stripe support for React-Native",
     "docs": {
       "cancelapplepayrequest": {
         "title": ".cancelApplePayRequest() -> Promise",
@@ -82,8 +82,8 @@
         "sidebar_label": "Google Pay"
       },
       "index": {
-        "title": "Start here",
-        "sidebar_label": "Start here"
+        "title": "Deprecation Notice",
+        "sidebar_label": "Deprecation Notice"
       },
       "installation": {
         "title": "Installation",
@@ -145,6 +145,10 @@
         "title": "Source",
         "sidebar_label": "Source"
       },
+      "start": {
+        "title": "(Deprecated) Start here",
+        "sidebar_label": "(Deprecated) Start here"
+      },
       "tests-local-ci": {
         "title": "Local CI",
         "sidebar_label": "Local CI"
@@ -179,8 +183,7 @@
       }
     },
     "links": {
-      "Docs": "Docs",
-      "Blog": "Blog"
+      "Docs": "Docs"
     },
     "categories": {
       "Overview": "Overview",

--- a/website/docs/pages/en/index.js
+++ b/website/docs/pages/en/index.js
@@ -5,18 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const React = require('react')
-const PropTypes = require('prop-types')
-const { Container, GridBlock } = require('../../core/CompLibrary')
+const React = require('react');
+const PropTypes = require('prop-types');
+const { Container, GridBlock } = require('../../core/CompLibrary');
 
-const siteConfig = require(process.cwd() + '/siteConfig') // eslint-disable-line
+const siteConfig = require(process.cwd() + '/siteConfig'); // eslint-disable-line
 
 function imgUrl(img) {
-  return `${siteConfig.baseUrl}img/${img}`
+  return `${siteConfig.baseUrl}img/${img}`;
 }
 
 function pageUrl(page, language) {
-  return `${siteConfig.baseUrl}${language ? `${language}/` : ''}${page}`
+  return `${siteConfig.baseUrl}${language ? `${language}/` : ''}${page}`;
 }
 
 class Button extends React.Component {
@@ -27,19 +27,19 @@ class Button extends React.Component {
           {this.props.children}
         </a>
       </div>
-    )
+    );
   }
 }
 
 Button.propTypes = {
   href: PropTypes.string.isRequired,
   children: PropTypes.any.isRequired,
-  target: PropTypes.string,
-}
+  target: PropTypes.string
+};
 
 Button.defaultProps = {
-  target: '_self',
-}
+  target: '_self'
+};
 
 const SplashContainer = props => (
   <div className="homeContainer">
@@ -47,18 +47,18 @@ const SplashContainer = props => (
       <div className="wrapper homeWrapper">{props.children}</div>
     </div>
   </div>
-)
+);
 
 SplashContainer.propTypes = {
-  children: PropTypes.any.isRequired,
-}
+  children: PropTypes.any.isRequired
+};
 
 const ProjectTitle = () => (
   <h2 className="projectTitle">
     {siteConfig.title}
     <small>{siteConfig.tagline}</small>
   </h2>
-)
+);
 
 const PromoSection = props => (
   <div className="section promoSection">
@@ -66,11 +66,11 @@ const PromoSection = props => (
       <div className="pluginRowBlock">{props.children}</div>
     </div>
   </div>
-)
+);
 
 PromoSection.propTypes = {
-  children: PropTypes.any.isRequired,
-}
+  children: PropTypes.any.isRequired
+};
 
 class HomeSplash extends React.Component {
   render() {
@@ -79,13 +79,13 @@ class HomeSplash extends React.Component {
         <div className="inner">
           <ProjectTitle />
           <PromoSection>
-            <Button href="https://github.com/tipsi/tipsi-stripe/tree/master/example">
-              Sample Project
+            <Button href="https://github.com/stripe/stripe-react-native">
+              Official library: @stripe/stripe-react-native
             </Button>
           </PromoSection>
         </div>
       </SplashContainer>
-    )
+    );
   }
 }
 
@@ -93,18 +93,18 @@ const Block = props => (
   <Container padding={['bottom', 'top']} id={props.id} background={props.background}>
     <GridBlock align="center" contents={props.children} layout={props.layout} />
   </Container>
-)
+);
 
 Block.propTypes = {
   id: PropTypes.string.isRequired,
   background: PropTypes.string.isRequired,
   children: PropTypes.any.isRequired,
-  layout: PropTypes.string.isRequired,
-}
+  layout: PropTypes.string.isRequired
+};
 
-const Showcase = (props) => {
+const Showcase = props => {
   if ((siteConfig.users || []).length === 0) {
-    return null
+    return null;
   }
 
   const showcase = siteConfig.users
@@ -113,29 +113,36 @@ const Showcase = (props) => {
       <a href={user.infoLink} key={user.caption}>
         <img src={user.image} title={user.caption} alt={user.caption} />
       </a>
-    ))
+    ));
 
   return (
-      <div className="productShowcaseSection paddingBottom">
+    <div className="productShowcaseSection paddingBottom">
       <h2>Quick navigation</h2>
-      <a href="/tipsi-stripe/docs/index.html">Start reading docs</a>
+      <p>
+        <a href="https://github.com/stripe/stripe-react-native">
+          Official library: @stripe/stripe-react-native
+        </a>
+      </p>
+      <p>
+        <a href="/tipsi-stripe/docs/index.html">(Deprecated) Start reading docs</a>
+      </p>
 
       <div className="logos">{showcase}</div>
     </div>
-  )
-}
+  );
+};
 
 Showcase.propTypes = {
-  language: PropTypes.string,
-}
+  language: PropTypes.string
+};
 
 Showcase.defaultProps = {
-  language: undefined,
-}
+  language: undefined
+};
 
 class Index extends React.Component {
   render() {
-    const { language = '' } = this.props
+    const { language = '' } = this.props;
 
     return (
       <div>
@@ -144,16 +151,16 @@ class Index extends React.Component {
           <Showcase language={language} />
         </div>
       </div>
-    )
+    );
   }
 }
 
 Index.propTypes = {
-  language: PropTypes.string,
-}
+  language: PropTypes.string
+};
 
 Index.defaultProps = {
-  language: undefined,
-}
+  language: undefined
+};
 
-module.exports = Index
+module.exports = Index;

--- a/website/docs/sidebars.json
+++ b/website/docs/sidebars.json
@@ -2,6 +2,7 @@
   "docs": {
     "Overview": [
       "index",
+      "start",
       "compatibility",
       "installation",
       "linking",
@@ -14,11 +15,7 @@
       "migrationIssues",
       "changelog"
     ],
-    "Objects": [
-      "token",
-      "source",
-      "paymentMethod"
-    ],
+    "Objects": ["token", "source", "paymentMethod"],
     "Native Pay -  & G": [
       "canMakeNativePayPayments",
       "deviceSupportsNativePay",
@@ -32,10 +29,7 @@
     "Create Source Object With Params": ["createsourcewithparamsparams"],
     "Components": ["paymentcardtextfield"],
     "Error Codes": ["errorcodes"],
-    "Tests": [
-      "tests-local-ci",
-      "tests-manual"
-    ],
+    "Tests": ["tests-local-ci", "tests-manual"],
     "Troubleshooting": [
       "troubleshooting-android",
       "troubleshooting-jest",

--- a/website/docs/siteConfig.js
+++ b/website/docs/siteConfig.js
@@ -11,33 +11,30 @@ const users = [
     caption: 'Tipsi',
     image: '/tipsi-stripe/img/tipsi-logo.png',
     infoLink: 'https://www.gettipsi.com',
-    pinned: true,
-  },
-]
+    pinned: true
+  }
+];
 
 const siteConfig = {
   title: 'tipsi-stripe',
-  tagline: 'Stripe support for React-Native',
+  tagline: '(Deprecated) Stripe support for React-Native',
   url: 'https://tipsi.github.io',
   baseUrl: '/tipsi-stripe/',
   projectName: 'tipsi-stripe',
-  headerLinks: [
-    { doc: 'index', label: 'Docs' },
-    { blog: true, label: 'Blog' },
-  ],
+  headerLinks: [{ doc: 'index', label: 'Docs' }],
   users,
   headerIcon: 'img/favicon.png',
   favicon: 'img/favicon.png',
   colors: {
     primaryColor: '#6A3549',
-    secondaryColor: '#5B3A51',
+    secondaryColor: '#5B3A51'
   },
   copyright: `Copyright © ${new Date().getFullYear()} Tipsi`,
   customDocsPath: 'docs-md',
   organizationName: 'tipsi',
   highlight: { theme: 'default' },
   scripts: ['https://buttons.github.io/buttons.js'],
-  repoUrl: 'https://github.com/tipsi/tipsi-stripe',
-}
+  repoUrl: 'https://github.com/tipsi/tipsi-stripe'
+};
 
-module.exports = siteConfig
+module.exports = siteConfig;


### PR DESCRIPTION
This PR points users of tipsi-stripe to the official Stripe react-native library, [@stripe/stripe-react-native](https://github.com/stripe/stripe-react-native). 

This happens in a few places
- The README.md for this repo
- The docs site for tipsi-stripe
- As a `console.warn` message on the CLI
- As a `console.warn` message on postinstall of the npm library

I did not update the version number for the NPM library, or PR/Issue templates for github.

Ideally, it would be great if we could also:

- [ ] agree on a plan / time / date to [Archive this library on GitHub](https://docs.github.com/en/repositories/archiving-a-github-repository/archiving-repositories)
- [ ] message users in the tipsi-stripe discord about migrating to the official library
- [ ] create a [pinned issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/pinning-an-issue-to-your-repository) on this repo pointing devs to the official library