### PR TITLE
Update stripe-ios dependency to support building against iOS 16 SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [11.0.0] - 2023-03-31
+
+### Breaking changes:
+
+- #863 Update stripe-ios dependency to support building against iOS 16 SDK
+
+To support this change, the minimum iOS version has been increased from 11 to 12.
+
+## [10.0.0] - 2022-06-22
+
+- #840 Add deprecation notices to: library, readme, docs, CLI
+
 ## [9.2.0] - 2021-10-19
 
 - #554 Android: forward error code & message on failed confirmPaymentIntent

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tipsi-stripe",
-  "version": "10.0.0",
+  "version": "11.0.0",
   "description": "React Native Stripe binding for iOS/Android platforms",
   "main": "src/index.js",
   "scripts": {

--- a/tipsi-stripe.podspec
+++ b/tipsi-stripe.podspec
@@ -13,11 +13,11 @@ Pod::Spec.new do |s|
   s.source         = { :git => 'https://github.com/tipsi/tipsi-stripe', :tag => s.version }
 
   s.requires_arc   = true
-  s.platform       = :ios, '11.0'
+  s.platform       = :ios, '12.0'
 
   s.preserve_paths = 'LICENSE', 'README.md'
   s.source_files   = 'ios/TPSStripe/**/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'Stripe', '>= 21.3.1'
+  s.dependency 'Stripe', '22.8.4'
 end


### PR DESCRIPTION
Firstly, I understand that this library is no longer maintained, and so I'm aware that this might never get merged in. However, there is an issue with the library as it stands, meaning that it will not build against the iOS 16 SDK. This is a problem since starting April 25, [Apple mandate that all submissions to the App Store must be built against the iOS 16 SDK or later](https://developer.apple.com/news/?id=jd9wcyov).

The underlying reason that the library does not support iOS 16 is due to the stripe-ios dependency, which is currently set at v21. Updating to v22 fixes this issue, but this also necessitates a bump of the minimum supported version of iOS to 12. This is why the changes in this PR also include a bump to the major package version of this library, as technically this is a breaking change for users who currently target iOS 11.

For those of us that need to incorporate these changes before (if?) the PR is merged, I would recommend using the excellent [`patch-package`](https://github.com/ds300/patch-package) tool, with the following patch:

``` patch
diff --git a/node_modules/tipsi-stripe/tipsi-stripe.podspec b/node_modules/tipsi-stripe/tipsi-stripe.podspec
index e95d222..5b29dd3 100644
--- a/node_modules/tipsi-stripe/tipsi-stripe.podspec
+++ b/node_modules/tipsi-stripe/tipsi-stripe.podspec
@@ -13,11 +13,11 @@ Pod::Spec.new do |s|
   s.source         = { :git => 'https://github.com/tipsi/tipsi-stripe', :tag => s.version }
 
   s.requires_arc   = true
-  s.platform       = :ios, '11.0'
+  s.platform       = :ios, '12.0'
 
   s.preserve_paths = 'LICENSE', 'README.md'
   s.source_files   = 'ios/TPSStripe/**/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'Stripe', '>= 21.3.1'
+  s.dependency 'Stripe', '22.8.4'
 end
```